### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.1] - 2025-12-02
+
+### Fixed
+- E2E tests now use relative URLs instead of hardcoded `localhost:3000`, enabling proper testing against preview deployments with `BASE_URL` environment variable
+- Results API pagination validation now returns proper 400 errors for invalid parameters (page < 1 or limit outside 1-100 range)
+
+### Changed
+- Extracted cache control header constants to shared module (`src/lib/constants/cacheControl.ts`) for reusability across API routes
+- Updated results API route to use `request.nextUrl` for proper Next.js 14 compatibility with dynamic rendering
+
+### Documentation
+- Clarified `NEXT_PUBLIC_SITE_URL` environment variable must include protocol (https://) in documentation
+- Added `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` environment variable documentation
+
+## [1.2.0] - 2025-12-01
+
+### Added
+- Complete race results history feature with M3 Design System
+- Material Design 3 (M3) components: Card, Chip, SearchBar with Korean optimization
+- Results browsing page with advanced filtering (date range, race type, track, search)
+- Pagination component with keyboard accessibility
+- Historical race results API endpoint with comprehensive filtering support
+- 22+ new components with complete test coverage (339 tests passing)
+
+### Changed
+- Integrated Pretendard font for optimal Korean typography (weights: 400, 500, 600, 700)
+- Extended Tailwind config with M3 color palette, typography scale, and elevation shadows
+- Added navigation link to results page in Header component
+
+## [1.1.0] - 2025-11-15
+
+### Added
+- Initial release with horse racing, cycle racing, and boat racing support
+- Real-time race schedule display
+- Race detail pages with entries, odds, and results
+- SEO optimization with sitemap and robots.txt
+- Google Analytics integration
+- Responsive design with mobile support
+
+### Infrastructure
+- Next.js 14 App Router
+- TypeScript strict mode
+- Tailwind CSS styling
+- Jest + React Testing Library for unit tests
+- Playwright for E2E tests
+- Vercel deployment with preview environments
+
+[1.2.1]: https://github.com/Prometheus-P/racelab/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/Prometheus-P/racelab/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/Prometheus-P/racelab/releases/tag/v1.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "racelab",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Update package.json version from 1.2.0 to 1.2.1
- Add CHANGELOG.md with detailed release notes following Keep a Changelog format
- Document all changes from PR #11 and earlier fixes

## Changes
This is a PATCH version bump for backwards-compatible bug fixes:
- E2E tests now support BASE_URL environment variable for preview deployments
- Results API pagination validation improvements (page >= 1, limit 1-100)
- Cache control constants extracted to shared module for reusability
- request.nextUrl usage for proper Next.js 14 dynamic rendering

## Semantic Versioning
Following semver, this is a PATCH release (1.2.0 → 1.2.1) for bug fixes and improvements without breaking changes or new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare 1.2.1 patch release metadata and document recent changes.

Bug Fixes:
- Document fixes to E2E test URLs and BASE_URL support for preview deployments.
- Document stricter pagination validation for the results API to reject invalid parameters.

Enhancements:
- Record extraction of shared cache-control constants and Next.js 14-compatible routing changes in the changelog.

Build:
- Bump package.json version from 1.2.0 to 1.2.1.

Documentation:
- Add a Keep a Changelog–style CHANGELOG.md capturing versions 1.1.0 through 1.2.1, including environment variable documentation updates.