### PR TITLE
feat(backtest): implement Quant Terminal MVP - Strategy DSL & Backtest Engine

### DIFF
--- a/db/migrations/004_quantlab_tier.sql
+++ b/db/migrations/004_quantlab_tier.sql
@@ -1,0 +1,274 @@
+-- Migration: 004_quantlab_tier
+-- Date: 2025-12-18
+-- Description: Add QuantLab tier for advanced backtesting features
+
+-- ====================================================
+-- Add QuantLab to client_tier enum
+-- ====================================================
+
+-- PostgreSQL requires creating a new enum type to add values safely
+-- First, add the new value to the enum
+ALTER TYPE client_tier ADD VALUE IF NOT EXISTS 'QuantLab' AFTER 'Gold';
+
+-- ====================================================
+-- Add backtest quota columns to clients table
+-- ====================================================
+
+-- Monthly backtest quota (-1 = unlimited)
+ALTER TABLE clients
+ADD COLUMN IF NOT EXISTS backtest_quota_monthly INTEGER DEFAULT 0;
+
+-- Used backtest count this month
+ALTER TABLE clients
+ADD COLUMN IF NOT EXISTS backtest_quota_used INTEGER DEFAULT 0;
+
+-- Quota reset timestamp
+ALTER TABLE clients
+ADD COLUMN IF NOT EXISTS backtest_quota_reset_at TIMESTAMPTZ;
+
+-- Max concurrent backtest jobs
+ALTER TABLE clients
+ADD COLUMN IF NOT EXISTS backtest_concurrent_limit INTEGER DEFAULT 0;
+
+-- Max backtest period in days
+ALTER TABLE clients
+ADD COLUMN IF NOT EXISTS backtest_max_period_days INTEGER DEFAULT 0;
+
+-- ====================================================
+-- Backtest Jobs Table
+-- ====================================================
+
+CREATE TYPE backtest_job_status AS ENUM (
+    'pending',
+    'running',
+    'completed',
+    'failed',
+    'cancelled'
+);
+
+CREATE TYPE backtest_job_priority AS ENUM (
+    'low',
+    'normal',
+    'high'
+);
+
+CREATE TABLE IF NOT EXISTS backtest_jobs (
+    id VARCHAR(50) PRIMARY KEY,  -- UUID
+    client_id INTEGER REFERENCES clients(id) NOT NULL,
+
+    -- Status tracking
+    status backtest_job_status NOT NULL DEFAULT 'pending',
+    priority backtest_job_priority NOT NULL DEFAULT 'normal',
+    progress INTEGER NOT NULL DEFAULT 0 CHECK (progress >= 0 AND progress <= 100),
+    progress_message TEXT,
+
+    -- Request data (JSON)
+    request_data JSONB NOT NULL,
+
+    -- Execution metrics
+    processed_races INTEGER DEFAULT 0,
+    total_races INTEGER DEFAULT 0,
+    estimated_duration_seconds INTEGER,
+    execution_time_ms INTEGER,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+
+    -- Error handling
+    error_code VARCHAR(50),
+    error_message TEXT,
+    error_details TEXT,
+    retry_count INTEGER DEFAULT 0,
+    max_retries INTEGER DEFAULT 3,
+
+    -- QStash integration
+    qstash_message_id VARCHAR(100),
+
+    -- Webhook notification
+    webhook_url TEXT
+);
+
+-- Indexes for job queries
+CREATE INDEX idx_backtest_jobs_client ON backtest_jobs(client_id);
+CREATE INDEX idx_backtest_jobs_status ON backtest_jobs(status);
+CREATE INDEX idx_backtest_jobs_created ON backtest_jobs(created_at DESC);
+CREATE INDEX idx_backtest_jobs_client_status ON backtest_jobs(client_id, status);
+
+-- ====================================================
+-- Backtest Results Table
+-- ====================================================
+
+CREATE TABLE IF NOT EXISTS backtest_results (
+    id SERIAL PRIMARY KEY,
+    job_id VARCHAR(50) REFERENCES backtest_jobs(id) ON DELETE CASCADE NOT NULL,
+
+    -- Summary metrics
+    total_races INTEGER NOT NULL,
+    matched_races INTEGER NOT NULL,
+    total_bets INTEGER NOT NULL,
+    wins INTEGER NOT NULL,
+    losses INTEGER NOT NULL,
+    refunds INTEGER DEFAULT 0,
+
+    -- Performance metrics
+    win_rate DECIMAL(5, 2),        -- %
+    roi DECIMAL(8, 2),             -- %
+    max_drawdown DECIMAL(8, 2),    -- %
+    final_capital BIGINT,          -- KRW
+    capital_return DECIMAL(8, 2),  -- %
+    avg_odds DECIMAL(6, 2),
+    avg_bet_amount BIGINT,
+    max_win_streak INTEGER,
+    max_lose_streak INTEGER,
+
+    -- Full result data (JSONB for flexibility)
+    full_result JSONB,
+
+    -- Metadata
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL  -- For cleanup
+);
+
+CREATE INDEX idx_backtest_results_job ON backtest_results(job_id);
+CREATE INDEX idx_backtest_results_expires ON backtest_results(expires_at);
+
+-- ====================================================
+-- Saved Strategies Table
+-- ====================================================
+
+CREATE TABLE IF NOT EXISTS saved_strategies (
+    id VARCHAR(100) PRIMARY KEY,  -- strategy id from JSON
+    client_id INTEGER REFERENCES clients(id) NOT NULL,
+
+    -- Strategy data
+    name VARCHAR(200) NOT NULL,
+    version VARCHAR(20) NOT NULL,
+    strategy_data JSONB NOT NULL,
+
+    -- Metadata
+    description TEXT,
+    tags TEXT[],
+    is_public BOOLEAN DEFAULT FALSE,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX idx_saved_strategies_client ON saved_strategies(client_id);
+CREATE INDEX idx_saved_strategies_tags ON saved_strategies USING GIN(tags);
+
+-- Trigger for updated_at
+CREATE TRIGGER update_saved_strategies_updated_at
+    BEFORE UPDATE ON saved_strategies
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ====================================================
+-- Backtest Usage Summary (for billing/analytics)
+-- ====================================================
+
+CREATE TABLE IF NOT EXISTS backtest_usage (
+    id SERIAL,
+    client_id INTEGER REFERENCES clients(id) NOT NULL,
+    job_id VARCHAR(50) REFERENCES backtest_jobs(id),
+
+    -- Usage metrics
+    period_days INTEGER NOT NULL,
+    races_processed INTEGER NOT NULL,
+    execution_time_ms INTEGER NOT NULL,
+
+    -- Billing period
+    billing_month DATE NOT NULL,  -- First day of the month
+
+    created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+-- Convert to hypertable for time-series queries
+SELECT create_hypertable('backtest_usage', 'created_at',
+    chunk_time_interval => INTERVAL '1 month',
+    if_not_exists => TRUE
+);
+
+CREATE INDEX idx_backtest_usage_client_month ON backtest_usage(client_id, billing_month);
+
+-- ====================================================
+-- Update existing clients with default backtest quotas
+-- ====================================================
+
+-- Bronze/Silver: No backtest access (default 0)
+-- Gold: 10 backtests/month, 2 concurrent, 90 days max
+-- QuantLab: Unlimited (-1), 10 concurrent, 365 days max
+
+UPDATE clients SET
+    backtest_quota_monthly =
+        CASE tier
+            WHEN 'Gold' THEN 10
+            WHEN 'QuantLab' THEN -1
+            ELSE 0
+        END,
+    backtest_concurrent_limit =
+        CASE tier
+            WHEN 'Gold' THEN 2
+            WHEN 'QuantLab' THEN 10
+            ELSE 0
+        END,
+    backtest_max_period_days =
+        CASE tier
+            WHEN 'Gold' THEN 90
+            WHEN 'QuantLab' THEN 365
+            ELSE 0
+        END,
+    backtest_quota_reset_at = date_trunc('month', NOW()) + INTERVAL '1 month'
+WHERE backtest_quota_reset_at IS NULL;
+
+-- ====================================================
+-- Function: Reset monthly backtest quotas
+-- ====================================================
+
+CREATE OR REPLACE FUNCTION reset_backtest_quotas()
+RETURNS void AS $$
+BEGIN
+    UPDATE clients
+    SET
+        backtest_quota_used = 0,
+        backtest_quota_reset_at = date_trunc('month', NOW()) + INTERVAL '1 month'
+    WHERE backtest_quota_reset_at <= NOW();
+END;
+$$ LANGUAGE plpgsql;
+
+-- ====================================================
+-- Cleanup Policy: Delete old results after expiry
+-- ====================================================
+
+CREATE OR REPLACE FUNCTION cleanup_expired_backtest_results()
+RETURNS INTEGER AS $$
+DECLARE
+    deleted_count INTEGER;
+BEGIN
+    WITH deleted AS (
+        DELETE FROM backtest_results
+        WHERE expires_at < NOW()
+        RETURNING id
+    )
+    SELECT COUNT(*) INTO deleted_count FROM deleted;
+
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ====================================================
+-- Comments for documentation
+-- ====================================================
+
+COMMENT ON COLUMN clients.backtest_quota_monthly IS 'Monthly backtest quota. -1 = unlimited';
+COMMENT ON COLUMN clients.backtest_quota_used IS 'Number of backtests used this month';
+COMMENT ON COLUMN clients.backtest_concurrent_limit IS 'Max concurrent running backtest jobs';
+COMMENT ON COLUMN clients.backtest_max_period_days IS 'Max date range for single backtest (days)';
+
+COMMENT ON TABLE backtest_jobs IS 'Tracks backtest job status and progress';
+COMMENT ON TABLE backtest_results IS 'Stores backtest results with TTL';
+COMMENT ON TABLE saved_strategies IS 'User-saved betting strategies';
+COMMENT ON TABLE backtest_usage IS 'Tracks backtest usage for billing';

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@upstash/qstash": "^2.8.4",
         "@vercel/analytics": "^1.5.0",
+        "@vercel/kv": "^3.0.0",
         "autoprefixer": "^10.4.22",
         "bull": "^4.16.5",
         "drizzle-orm": "^0.45.0",
@@ -26,6 +28,7 @@
         "recharts": "^3.5.1",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.9.3",
+        "zod": "^4.2.1",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -38,6 +41,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^30.0.0",
         "@types/pg": "^8.15.6",
+        "@types/uuid": "^10.0.0",
         "babel-jest": "^30.2.0",
         "drizzle-kit": "^0.31.8",
         "eslint": "^8.57.1",
@@ -4565,6 +4569,13 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -5116,6 +5127,26 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/qstash": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@upstash/qstash/-/qstash-2.8.4.tgz",
+      "integrity": "sha512-iojHWUlRoC3M2e4XQ1NFEgC+7Orurrm5uIrPn5WilU7LvWQoocyjYBXR0VUalXkeMAmFyk4blF0EOYZY4igdIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": ">=4.2.0",
+        "jose": "^5.2.3",
+        "neverthrow": "^7.0.1"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.35.8",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.35.8.tgz",
+      "integrity": "sha512-QqLpVCD9PCPE6hlRzOkz864nfijSdazxtyJLIy9ZeTh6kU2nBIKKfjT5HMHjIRD4BCm6TK1dbUT9pxhFjcvpng==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
@@ -5152,6 +5183,18 @@
         "vue-router": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {
@@ -6229,6 +6272,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -9896,6 +9945,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10434,6 +10492,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/neverthrow": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-7.2.0.tgz",
+      "integrity": "sha512-iGBUfFB7yPczHHtA8dksKTJ9E8TESNTAx1UQWW6TzMF280vo9jdPYpLUXrMN1BCkPdHFdNG3fxOt2CUad8KhAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/next": {
       "version": "14.2.33",
@@ -13275,6 +13342,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -13931,6 +14004,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
+      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@upstash/qstash": "^2.8.4",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/kv": "^3.0.0",
     "autoprefixer": "^10.4.22",
     "bull": "^4.16.5",
     "drizzle-orm": "^0.45.0",
@@ -39,6 +41,7 @@
     "recharts": "^3.5.1",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.9.3",
+    "zod": "^4.2.1",
     "zustand": "^5.0.9"
   },
   "devDependencies": {
@@ -51,6 +54,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/pg": "^8.15.6",
+    "@types/uuid": "^10.0.0",
     "babel-jest": "^30.2.0",
     "drizzle-kit": "^0.31.8",
     "eslint": "^8.57.1",

--- a/src/app/api/jobs/backtest/worker/route.ts
+++ b/src/app/api/jobs/backtest/worker/route.ts
@@ -1,0 +1,387 @@
+/**
+ * Backtest Worker Handler
+ *
+ * POST /api/jobs/backtest/worker
+ *
+ * Processes backtest jobs from QStash queue.
+ * This endpoint receives webhook calls from Upstash QStash.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Receiver } from '@upstash/qstash';
+import {
+  getJob,
+  updateJobStatus,
+  updateJobProgress,
+  failJob,
+  saveResult,
+  deleteCheckpoint,
+} from '@/lib/backtest/jobManager';
+import { BacktestExecutor, MockRaceDataSource } from '@/lib/backtest/executor';
+import { enhanceSummary } from '@/lib/backtest/metrics';
+import type { QStashBacktestPayload, JobError } from '@/lib/backtest/types';
+import type { BacktestResult } from '@/lib/strategy/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60; // Vercel Pro limit
+
+// QStash signature verification
+const receiver = new Receiver({
+  currentSigningKey: process.env.QSTASH_CURRENT_SIGNING_KEY!,
+  nextSigningKey: process.env.QSTASH_NEXT_SIGNING_KEY!,
+});
+
+/**
+ * POST handler for QStash webhook
+ */
+export async function POST(request: NextRequest) {
+  const startTime = Date.now();
+
+  // 1. Verify QStash signature (skip in development)
+  if (process.env.NODE_ENV === 'production') {
+    const signature = request.headers.get('upstash-signature');
+    const body = await request.text();
+
+    if (!signature) {
+      console.error('[Worker] Missing QStash signature');
+      return NextResponse.json(
+        { error: 'Missing signature' },
+        { status: 401 }
+      );
+    }
+
+    try {
+      const isValid = await receiver.verify({
+        signature,
+        body,
+      });
+
+      if (!isValid) {
+        console.error('[Worker] Invalid QStash signature');
+        return NextResponse.json(
+          { error: 'Invalid signature' },
+          { status: 401 }
+        );
+      }
+
+      // Parse body after verification
+      const payload = JSON.parse(body) as QStashBacktestPayload;
+      return processJob(payload, startTime);
+    } catch (error) {
+      console.error('[Worker] Signature verification failed:', error);
+      return NextResponse.json(
+        { error: 'Signature verification failed' },
+        { status: 401 }
+      );
+    }
+  } else {
+    // Development mode - skip signature verification
+    try {
+      const payload = (await request.json()) as QStashBacktestPayload;
+      return processJob(payload, startTime);
+    } catch (error) {
+      console.error('[Worker] Failed to parse payload:', error);
+      return NextResponse.json(
+        { error: 'Invalid payload' },
+        { status: 400 }
+      );
+    }
+  }
+}
+
+/**
+ * Process the backtest job
+ */
+async function processJob(payload: QStashBacktestPayload, startTime: number) {
+  const { jobId, clientId, request: backtestRequest } = payload;
+
+  console.log(`[Worker] Processing job ${jobId} for client ${clientId}`);
+
+  // 2. Get job from KV
+  const job = await getJob(jobId);
+
+  if (!job) {
+    console.error(`[Worker] Job not found: ${jobId}`);
+    return NextResponse.json(
+      { error: 'Job not found' },
+      { status: 404 }
+    );
+  }
+
+  // 3. Check if job is already completed or cancelled
+  if (job.status === 'completed' || job.status === 'cancelled') {
+    console.log(`[Worker] Job ${jobId} already ${job.status}, skipping`);
+    return NextResponse.json({
+      message: `Job already ${job.status}`,
+      jobId,
+    });
+  }
+
+  // 4. Mark job as running
+  await updateJobStatus(jobId, 'running', {
+    progressMessage: 'Starting backtest execution',
+  });
+
+  try {
+    // 5. Create data source
+    // In production, this would use a real database source
+    // For now, using MockRaceDataSource for testing
+    const dataSource = new MockRaceDataSource();
+
+    // Generate mock data based on date range
+    await generateMockData(dataSource, backtestRequest.dateRange);
+
+    // 6. Create executor with progress callback
+    let lastProgressUpdate = 0;
+    let lastProcessed = 0;
+    let lastTotal = 0;
+
+    const executor = new BacktestExecutor(
+      backtestRequest,
+      dataSource,
+      {
+        initialCapital: backtestRequest.initialCapital,
+        defaultBetAmount: backtestRequest.strategy.stake?.fixed,
+        onProgress: async (progress: number, message: string) => {
+          // Rate limit progress updates
+          const now = Date.now();
+          if (now - lastProgressUpdate > 2000 || progress === 100) { // Every 2 seconds
+            lastProgressUpdate = now;
+            await updateJobProgress(
+              jobId,
+              progress,
+              message,
+              lastProcessed,
+              lastTotal
+            );
+          }
+        },
+      }
+    );
+
+    // 7. Execute backtest
+    console.log(`[Worker] Starting backtest for ${backtestRequest.dateRange.from} to ${backtestRequest.dateRange.to}`);
+    const result = await executor.execute(backtestRequest);
+    lastProcessed = result.summary.totalRaces;
+    lastTotal = result.summary.totalRaces;
+
+    // 8. Enhance summary with additional metrics
+    const enhancedSummary = enhanceSummary(result.summary, result.bets, result.equityCurve);
+    const finalResult: BacktestResult = {
+      ...result,
+      summary: {
+        ...result.summary,
+        ...enhancedSummary,
+      },
+    };
+
+    // 9. Save result
+    await saveResult(jobId, clientId, finalResult);
+
+    // 10. Mark job as completed
+    const executionTimeMs = Date.now() - startTime;
+    await updateJobStatus(jobId, 'completed', {
+      progress: 100,
+      progressMessage: 'Backtest completed successfully',
+      executionTimeMs,
+      processedRaces: result.summary.totalRaces,
+      totalRaces: result.summary.totalRaces,
+    });
+
+    // 11. Clean up checkpoint if exists
+    await deleteCheckpoint(jobId);
+
+    console.log(`[Worker] Job ${jobId} completed in ${executionTimeMs}ms`);
+    console.log(`[Worker] Results: ${result.summary.totalBets} bets, ${result.summary.winRate.toFixed(1)}% win rate, ${result.summary.roi.toFixed(2)}% ROI`);
+
+    return NextResponse.json({
+      success: true,
+      jobId,
+      summary: {
+        totalBets: result.summary.totalBets,
+        winRate: result.summary.winRate,
+        roi: result.summary.roi,
+        totalProfit: result.summary.totalProfit,
+      },
+      executionTimeMs,
+    });
+  } catch (error) {
+    console.error(`[Worker] Job ${jobId} failed:`, error);
+
+    const jobError: JobError = {
+      code: 'INTERNAL_ERROR',
+      message: error instanceof Error ? error.message : 'Unknown error occurred',
+      details: error instanceof Error ? error.stack : undefined,
+      retryable: isRetryableError(error),
+    };
+
+    await failJob(jobId, jobError);
+
+    // Return 500 to trigger QStash retry (if retryable)
+    if (jobError.retryable) {
+      return NextResponse.json(
+        { error: jobError.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        error: jobError.message,
+        code: jobError.code,
+      },
+      { status: 200 } // Don't retry non-retryable errors
+    );
+  }
+}
+
+/**
+ * Check if error is retryable
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof Error) {
+    // Network errors, timeouts are retryable
+    if (
+      error.message.includes('ECONNRESET') ||
+      error.message.includes('ETIMEDOUT') ||
+      error.message.includes('ECONNREFUSED') ||
+      error.message.includes('timeout')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Mock entry type for generating test data
+ */
+interface MockEntry {
+  raceId: string;
+  entryNo: number;
+  odds_win: number;
+  odds_place: number;
+  odds_drift_pct: number;
+  odds_stddev: number;
+  popularity_rank: number;
+  pool_total: number;
+  pool_win_pct: number;
+  oddsTimeline: Array<{ time: Date; odds_win: number }>;
+}
+
+/**
+ * Generate mock race data for testing
+ * In production, this would be replaced with actual database queries
+ */
+async function generateMockData(
+  dataSource: MockRaceDataSource,
+  dateRange: { from: string; to: string }
+): Promise<void> {
+  const from = new Date(dateRange.from);
+  const to = new Date(dateRange.to);
+  const days = Math.ceil((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
+
+  // Generate mock races
+  for (let d = 0; d <= days; d++) {
+    const date = new Date(from);
+    date.setDate(date.getDate() + d);
+    const dateStr = date.toISOString().split('T')[0];
+
+    // Skip weekdays (Korean racing is mainly weekends)
+    const dayOfWeek = date.getDay();
+    if (dayOfWeek !== 0 && dayOfWeek !== 6) continue;
+
+    // Generate 8-12 races per day
+    const raceCount = 8 + Math.floor(Math.random() * 5);
+    const tracks = ['seoul', 'busan', 'jeju'];
+    const track = tracks[Math.floor(Math.random() * tracks.length)];
+
+    for (let r = 1; r <= raceCount; r++) {
+      const raceId = `horse-${track}-${r}-${dateStr.replace(/-/g, '')}`;
+      const entryCount = 8 + Math.floor(Math.random() * 8); // 8-15 entries
+
+      // Generate entries with odds
+      const entries: MockEntry[] = [];
+      const totalPool = 50000000 + Math.random() * 100000000;
+
+      for (let e = 1; e <= entryCount; e++) {
+        // Generate realistic odds distribution
+        const baseOdds = 1.5 + Math.random() * 50;
+        const firstOdds = baseOdds * (0.8 + Math.random() * 0.4);
+        const lastOdds = baseOdds;
+        const oddsDriftPct = ((lastOdds - firstOdds) / firstOdds) * 100;
+
+        entries.push({
+          raceId,
+          entryNo: e,
+          odds_win: lastOdds,
+          odds_place: lastOdds * 0.4,
+          odds_drift_pct: oddsDriftPct,
+          odds_stddev: Math.random() * 2,
+          popularity_rank: e, // Will be sorted later
+          pool_total: totalPool,
+          pool_win_pct: 100 / entryCount + (Math.random() - 0.5) * 10,
+          oddsTimeline: [
+            { time: new Date(`${dateStr}T10:00:00Z`), odds_win: firstOdds },
+            { time: new Date(`${dateStr}T11:00:00Z`), odds_win: (firstOdds + lastOdds) / 2 },
+            { time: new Date(`${dateStr}T12:00:00Z`), odds_win: lastOdds },
+          ],
+        });
+      }
+
+      // Sort by odds and assign popularity rank
+      entries.sort((a, b) => a.odds_win - b.odds_win);
+      entries.forEach((entry, idx) => {
+        entry.popularity_rank = idx + 1;
+      });
+
+      const raceContext = {
+        raceId,
+        raceDate: dateStr,
+        raceNo: r,
+        track,
+        raceType: 'horse' as const,
+        entries,
+      };
+
+      // Determine winner (biased toward lower odds horses)
+      const winnerIndex = Math.min(
+        Math.floor(Math.random() * Math.random() * entryCount),
+        entryCount - 1
+      );
+      const winner = entries[winnerIndex];
+
+      // Generate random places (2nd and 3rd)
+      const otherEntries = entries.filter((_, i) => i !== winnerIndex);
+      const shuffled = otherEntries.sort(() => Math.random() - 0.5);
+      const places = [winner.entryNo, shuffled[0].entryNo, shuffled[1].entryNo];
+
+      // Create finish positions map
+      const finishPositions = new Map<number, number>();
+      places.forEach((entryNo, idx) => {
+        finishPositions.set(entryNo, idx + 1);
+      });
+
+      // Create dividends maps
+      const winDividends = new Map<number, number>();
+      winDividends.set(winner.entryNo, Math.round(winner.odds_win * 100) / 100);
+
+      const placeDividends = new Map<number, number>();
+      places.slice(0, 3).forEach((no) => {
+        const entry = entries.find((e) => e.entryNo === no)!;
+        placeDividends.set(no, Math.round(entry.odds_place * 100) / 100);
+      });
+
+      const result = {
+        raceId,
+        finishPositions,
+        dividends: {
+          win: winDividends,
+          place: placeDividends,
+        },
+      };
+
+      dataSource.addRace(raceContext, result);
+    }
+  }
+}

--- a/src/app/api/v1/backtest/[jobId]/result/route.ts
+++ b/src/app/api/v1/backtest/[jobId]/result/route.ts
@@ -1,0 +1,163 @@
+/**
+ * B2B Backtest API - Job Result Endpoint
+ *
+ * GET /api/v1/backtest/[jobId]/result
+ *
+ * Returns the result of a completed backtest job.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  withB2BAuthParams,
+  createFeatureDeniedResponse,
+  type B2BRequest,
+} from '@/lib/api-helpers/apiAuth';
+import { getJob, getResult } from '@/lib/backtest/jobManager';
+import { hasBacktestAccess } from '@/lib/db/schema/clients';
+import type { GetJobResultResponse } from '@/lib/backtest/types';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ jobId: string }> };
+
+async function handler(request: B2BRequest, { params }: RouteContext) {
+  const client = request.b2bClient!;
+  const { jobId } = await params;
+
+  // 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(client.tier)) {
+    return createFeatureDeniedResponse('Backtest', 'Gold');
+  }
+
+  // 작업 조회
+  const job = await getJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: `Backtest job not found: ${jobId}`,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 }
+    );
+  }
+
+  // 권한 확인 (본인 작업만 조회 가능)
+  if (job.clientId !== client.clientId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this job',
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 403 }
+    );
+  }
+
+  // 완료되지 않은 작업
+  if (job.status !== 'completed') {
+    const response: GetJobResultResponse = {
+      jobId: job.id,
+      status: job.status,
+    };
+
+    // 진행 중인 경우 상태 정보 제공
+    const statusInfo =
+      job.status === 'pending'
+        ? 'Job is waiting in queue'
+        : job.status === 'running'
+          ? `Job is processing (${job.progress}%)`
+          : job.status === 'failed'
+            ? `Job failed: ${job.error?.message || 'Unknown error'}`
+            : 'Job was cancelled';
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: response,
+        message: statusInfo,
+        timestamp: new Date().toISOString(),
+      },
+      { status: job.status === 'failed' || job.status === 'cancelled' ? 200 : 202 }
+    );
+  }
+
+  // 결과 조회
+  const result = await getResult(jobId);
+
+  if (!result) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'RESULT_EXPIRED',
+          message: 'Result has expired or was not stored properly',
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 410 }
+    );
+  }
+
+  // 전체 결과 포함 여부 확인 (query param)
+  const url = new URL(request.url);
+  const includeFull = url.searchParams.get('full') === 'true';
+  const includeBets = url.searchParams.get('bets') === 'true';
+  const includeEquityCurve = url.searchParams.get('equity') === 'true';
+
+  // 응답 생성
+  const response: GetJobResultResponse = {
+    jobId: job.id,
+    status: job.status,
+    summary: result.summary,
+    expiresAt: result.expiresAt,
+  };
+
+  // 전체 결과 포함 (요청 시)
+  if (includeFull && result.fullResult) {
+    response.fullResult = result.fullResult;
+  } else if (result.fullResult) {
+    // 부분 데이터 포함
+    if (includeBets) {
+      response.fullResult = {
+        ...response.fullResult!,
+        request: result.fullResult.request,
+        summary: result.fullResult.summary,
+        bets: result.fullResult.bets,
+        equityCurve: [],
+        executedAt: result.fullResult.executedAt,
+        executionTimeMs: result.fullResult.executionTimeMs,
+      };
+    }
+    if (includeEquityCurve) {
+      response.fullResult = {
+        ...response.fullResult!,
+        request: result.fullResult.request,
+        summary: result.fullResult.summary,
+        bets: response.fullResult?.bets ?? [],
+        equityCurve: result.fullResult.equityCurve,
+        executedAt: result.fullResult.executedAt,
+        executionTimeMs: result.fullResult.executionTimeMs,
+      };
+    }
+  }
+
+  // 다운로드 URL 생성 (대용량 결과용 - 추후 구현)
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://api.racelab.kr';
+  response.downloadUrl = `${baseUrl}/api/v1/backtest/${jobId}/result?full=true`;
+
+  return NextResponse.json({
+    success: true,
+    data: response,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const GET = withB2BAuthParams<{ jobId: string }>(handler);

--- a/src/app/api/v1/backtest/[jobId]/route.ts
+++ b/src/app/api/v1/backtest/[jobId]/route.ts
@@ -1,0 +1,182 @@
+/**
+ * B2B Backtest API - Job Status Endpoint
+ *
+ * GET /api/v1/backtest/[jobId]
+ *
+ * Returns current status of a backtest job.
+ */
+
+import { NextResponse } from 'next/server';
+import {
+  withB2BAuthParams,
+  createFeatureDeniedResponse,
+  type B2BRequest,
+} from '@/lib/api-helpers/apiAuth';
+import { getJob, updateJobStatus } from '@/lib/backtest/jobManager';
+import { hasBacktestAccess } from '@/lib/db/schema/clients';
+import type { GetJobStatusResponse } from '@/lib/backtest/types';
+import { ESTIMATED_MS_PER_RACE } from '@/lib/backtest/types';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ jobId: string }> };
+
+async function handler(request: B2BRequest, { params }: RouteContext) {
+  const client = request.b2bClient!;
+  const { jobId } = await params;
+
+  // 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(client.tier)) {
+    return createFeatureDeniedResponse('Backtest', 'Gold');
+  }
+
+  // 작업 조회
+  const job = await getJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: `Backtest job not found: ${jobId}`,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 }
+    );
+  }
+
+  // 권한 확인 (본인 작업만 조회 가능)
+  if (job.clientId !== client.clientId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this job',
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 403 }
+    );
+  }
+
+  // 예상 남은 시간 계산
+  let estimatedRemainingSeconds: number | undefined;
+  if (job.status === 'running' && job.totalRaces && job.processedRaces) {
+    const remaining = job.totalRaces - job.processedRaces;
+    estimatedRemainingSeconds = Math.ceil((remaining * ESTIMATED_MS_PER_RACE) / 1000);
+  }
+
+  // 응답 생성
+  const response: GetJobStatusResponse = {
+    jobId: job.id,
+    status: job.status,
+    progress: job.progress,
+    progressMessage: job.progressMessage,
+    processed:
+      job.processedRaces !== undefined && job.totalRaces !== undefined
+        ? { races: job.processedRaces, total: job.totalRaces }
+        : undefined,
+    error:
+      job.error
+        ? { code: job.error.code, message: job.error.message }
+        : undefined,
+    estimatedRemainingSeconds,
+    createdAt: job.createdAt,
+    startedAt: job.startedAt,
+    completedAt: job.completedAt,
+  };
+
+  return NextResponse.json({
+    success: true,
+    data: response,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const GET = withB2BAuthParams<{ jobId: string }>(handler);
+
+/**
+ * DELETE /api/v1/backtest/[jobId]
+ *
+ * Cancel a pending or running backtest job.
+ */
+async function deleteHandler(request: B2BRequest, { params }: RouteContext) {
+  const client = request.b2bClient!;
+  const { jobId } = await params;
+
+  // 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(client.tier)) {
+    return createFeatureDeniedResponse('Backtest', 'Gold');
+  }
+
+  // 작업 조회
+  const job = await getJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: `Backtest job not found: ${jobId}`,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 404 }
+    );
+  }
+
+  // 권한 확인
+  if (job.clientId !== client.clientId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'FORBIDDEN',
+          message: 'You do not have access to this job',
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 403 }
+    );
+  }
+
+  // 이미 완료된 작업은 취소 불가
+  if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'INVALID_STATUS',
+          message: `Cannot cancel job with status: ${job.status}`,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  // 작업 취소
+  const updatedJob = await updateJobStatus(jobId, 'cancelled', {
+    error: {
+      code: 'CANCELLED',
+      message: 'Job cancelled by user',
+      retryable: false,
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      jobId,
+      status: updatedJob?.status ?? 'cancelled',
+      message: 'Job has been cancelled',
+    },
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const DELETE = withB2BAuthParams<{ jobId: string }>(deleteHandler);

--- a/src/app/api/v1/backtest/route.ts
+++ b/src/app/api/v1/backtest/route.ts
@@ -1,0 +1,219 @@
+/**
+ * B2B Backtest API - Create Job Endpoint
+ *
+ * POST /api/v1/backtest
+ *
+ * Creates a new backtest job for async processing.
+ * Requires Gold or QuantLab tier.
+ */
+
+import { NextResponse } from 'next/server';
+import { Client } from '@upstash/qstash';
+import {
+  withB2BAuth,
+  createFeatureDeniedResponse,
+  type B2BRequest,
+} from '@/lib/api-helpers/apiAuth';
+import {
+  createJob,
+  checkQuota,
+  calculatePeriodDays,
+  getQueuePosition,
+  incrementQuotaUsage,
+} from '@/lib/backtest/jobManager';
+import { validateBacktestRequest } from '@/lib/strategy/validator';
+import { hasBacktestAccess } from '@/lib/db/schema/clients';
+import type {
+  CreateBacktestJobRequest,
+  CreateBacktestJobResponse,
+  QStashBacktestPayload,
+} from '@/lib/backtest/types';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+// QStash client
+const qstash = new Client({
+  token: process.env.QSTASH_TOKEN!,
+});
+
+// Worker endpoint URL
+const WORKER_URL = process.env.BACKTEST_WORKER_URL
+  || `${process.env.NEXT_PUBLIC_SITE_URL}/api/jobs/backtest/worker`;
+
+async function handler(request: B2BRequest) {
+  const client = request.b2bClient!;
+
+  // 1. 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(client.tier)) {
+    return createFeatureDeniedResponse('Backtest', 'Gold');
+  }
+
+  // 2. 요청 본문 파싱
+  let body: CreateBacktestJobRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'Invalid JSON in request body',
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  // 3. 전략 검증
+  const validation = validateBacktestRequest(body.request);
+  if (!validation.valid) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid backtest request',
+          details: validation.errors,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 400 }
+    );
+  }
+
+  // 4. 기간 계산 및 할당량 확인
+  const periodDays = calculatePeriodDays(body.request.dateRange);
+  const quotaCheck = await checkQuota(client.clientId, client.tier, periodDays);
+
+  if (!quotaCheck.allowed) {
+    const messages: Record<string, string> = {
+      MONTHLY_LIMIT_EXCEEDED: `Monthly backtest quota exceeded. Used: ${quotaCheck.quota.used}/${quotaCheck.quota.monthlyLimit}`,
+      CONCURRENT_LIMIT_EXCEEDED: `Too many concurrent backtests. Running: ${quotaCheck.quota.currentRunning}/${quotaCheck.quota.concurrentLimit}`,
+      PERIOD_LIMIT_EXCEEDED: `Period too long. Max: ${quotaCheck.quota.maxPeriodDays} days, requested: ${periodDays} days`,
+    };
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: 'QUOTA_EXCEEDED',
+          message: messages[quotaCheck.reason!] || 'Quota exceeded',
+          quota: quotaCheck.quota,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 429 }
+    );
+  }
+
+  // 5. 작업 생성
+  const job = await createJob(client.clientId, body.request, body.priority);
+
+  // 6. 할당량 사용량 증가
+  await incrementQuotaUsage(client.clientId);
+
+  // 7. QStash에 작업 발행
+  const payload: QStashBacktestPayload = {
+    jobId: job.id,
+    clientId: client.clientId,
+    request: body.request,
+  };
+
+  try {
+    const qstashResponse = await qstash.publishJSON({
+      url: WORKER_URL,
+      body: payload,
+      retries: 3,
+      delay: 0,
+    });
+
+    // QStash 메시지 ID 저장 (옵션)
+    console.log(`[Backtest] Job ${job.id} published to QStash: ${qstashResponse.messageId}`);
+  } catch (qstashError) {
+    console.error('[Backtest] Failed to publish to QStash:', qstashError);
+    // QStash 실패해도 작업은 생성됨 - 수동 처리 가능
+  }
+
+  // 8. 큐 위치 조회
+  const queuePosition = await getQueuePosition(job.id, client.clientId);
+
+  // 9. 응답 생성
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://api.racelab.kr';
+  const response: CreateBacktestJobResponse = {
+    jobId: job.id,
+    status: job.status,
+    estimatedDuration: job.estimatedDuration ?? 30,
+    queuePosition,
+    statusUrl: `${baseUrl}/api/v1/backtest/${job.id}`,
+    resultUrl: `${baseUrl}/api/v1/backtest/${job.id}/result`,
+  };
+
+  return NextResponse.json(
+    {
+      success: true,
+      data: response,
+      quota: {
+        remaining: quotaCheck.quota.remaining,
+        monthlyLimit: quotaCheck.quota.monthlyLimit,
+        resetAt: quotaCheck.quota.resetAt,
+      },
+      timestamp: new Date().toISOString(),
+    },
+    { status: 202 }
+  );
+}
+
+export const POST = withB2BAuth(handler);
+
+/**
+ * GET /api/v1/backtest
+ *
+ * List client's backtest jobs
+ */
+async function listHandler(request: B2BRequest) {
+  const client = request.b2bClient!;
+
+  // 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(client.tier)) {
+    return createFeatureDeniedResponse('Backtest', 'Gold');
+  }
+
+  const url = new URL(request.url);
+  const page = parseInt(url.searchParams.get('page') || '1', 10);
+  const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 100);
+  const status = url.searchParams.get('status');
+
+  const { getClientJobs } = await import('@/lib/backtest/jobManager');
+  const { jobs, total } = await getClientJobs(client.clientId, {
+    limit,
+    offset: (page - 1) * limit,
+    status: status ? [status as 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'] : undefined,
+  });
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      jobs: jobs.map((job) => ({
+        jobId: job.id,
+        status: job.status,
+        strategyName: job.request.strategy.name,
+        dateRange: job.request.dateRange,
+        progress: job.progress,
+        createdAt: job.createdAt,
+        completedAt: job.completedAt,
+      })),
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    },
+    timestamp: new Date().toISOString(),
+  });
+}
+
+export const GET = withB2BAuth(listHandler);

--- a/src/app/api/v1/data/odds-history/[raceId]/route.ts
+++ b/src/app/api/v1/data/odds-history/[raceId]/route.ts
@@ -39,6 +39,7 @@ const TIER_LIMITS = {
   Bronze: 1000,
   Silver: 10000,
   Gold: 100000,
+  QuantLab: 500000, // Higher limit for QuantLab tier
 };
 
 type RouteParams = { raceId: string };

--- a/src/lib/backtest/executor.ts
+++ b/src/lib/backtest/executor.ts
@@ -1,0 +1,517 @@
+/**
+ * Backtest Executor
+ *
+ * 전략을 과거 데이터에 적용하여 성과를 측정하는 백테스팅 엔진
+ */
+
+import {
+  StrategyEvaluator,
+  type RaceContext,
+  type EvaluationResult,
+} from '../strategy/evaluator';
+import type {
+  BacktestRequest,
+  BacktestResult,
+  BacktestSummary,
+  BetRecord,
+  EquityPoint,
+} from '../strategy/types';
+import type { WorkerCheckpoint } from './types';
+import { PROGRESS_UPDATE_INTERVAL } from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * 백테스트 실행 옵션
+ */
+export interface ExecutorOptions {
+  /** 초기 자본금 */
+  initialCapital: number;
+
+  /** 기본 베팅 금액 */
+  defaultBetAmount: number;
+
+  /** 진행률 콜백 */
+  onProgress?: (progress: number, message: string) => Promise<void>;
+
+  /** 체크포인트 저장 콜백 */
+  onCheckpoint?: (checkpoint: WorkerCheckpoint) => Promise<void>;
+
+  /** 타임아웃 체크 콜백 */
+  shouldStop?: () => boolean;
+}
+
+/**
+ * 경주 데이터 소스 인터페이스
+ */
+export interface RaceDataSource {
+  /** 날짜 범위의 경주 ID 목록 가져오기 */
+  getRaceIds(dateFrom: string, dateTo: string, filters?: RaceFilters): Promise<string[]>;
+
+  /** 경주 상세 데이터 가져오기 */
+  getRaceContext(raceId: string): Promise<RaceContext | null>;
+
+  /** 경주 결과 가져오기 */
+  getRaceResult(raceId: string): Promise<RaceResultData | null>;
+}
+
+export interface RaceFilters {
+  raceTypes?: ('horse' | 'cycle' | 'boat')[];
+  tracks?: string[];
+  grades?: string[];
+}
+
+export interface RaceResultData {
+  raceId: string;
+  finishPositions: Map<number, number>; // entryNo -> position (1, 2, 3, ...)
+  dividends: {
+    win: Map<number, number>; // entryNo -> 배당률
+    place?: Map<number, number>;
+  };
+  canceled?: boolean;
+}
+
+// =============================================================================
+// Backtest Executor
+// =============================================================================
+
+/**
+ * 백테스트 실행기
+ */
+export class BacktestExecutor {
+  private evaluator: StrategyEvaluator;
+  private dataSource: RaceDataSource;
+  private options: ExecutorOptions;
+
+  constructor(
+    request: BacktestRequest,
+    dataSource: RaceDataSource,
+    options: Partial<ExecutorOptions> = {}
+  ) {
+    this.evaluator = new StrategyEvaluator(request.strategy);
+    this.dataSource = dataSource;
+    this.options = {
+      initialCapital: options.initialCapital ?? request.initialCapital ?? 1_000_000,
+      defaultBetAmount: options.defaultBetAmount ?? 10_000,
+      onProgress: options.onProgress,
+      onCheckpoint: options.onCheckpoint,
+      shouldStop: options.shouldStop,
+    };
+  }
+
+  /**
+   * 백테스트 실행
+   */
+  async execute(request: BacktestRequest): Promise<BacktestResult> {
+    const startTime = Date.now();
+    const strategy = request.strategy;
+
+    // 경주 ID 목록 가져오기
+    const raceIds = await this.dataSource.getRaceIds(
+      request.dateRange.from,
+      request.dateRange.to,
+      {
+        raceTypes: request.filters?.raceTypes ?? strategy.filters?.raceTypes,
+        tracks: request.filters?.tracks ?? strategy.filters?.tracks,
+        grades: request.filters?.grades ?? strategy.filters?.grades,
+      }
+    );
+
+    const totalRaces = raceIds.length;
+    let processedRaces = 0;
+    let matchedRaces = 0;
+
+    // 베팅 기록
+    const bets: BetRecord[] = [];
+    let currentCapital = this.options.initialCapital;
+    let peakCapital = currentCapital;
+    let maxDrawdown = 0;
+
+    // 자본 곡선
+    const equityCurve: EquityPoint[] = [];
+    let lastEquityDate = '';
+
+    // 연승/연패 추적
+    let currentStreak = 0;
+    let maxWinStreak = 0;
+    let maxLoseStreak = 0;
+
+    // 각 경주 처리
+    for (const raceId of raceIds) {
+      // 타임아웃 체크
+      if (this.options.shouldStop?.()) {
+        break;
+      }
+
+      // 경주 데이터 가져오기
+      const raceContext = await this.dataSource.getRaceContext(raceId);
+      if (!raceContext) {
+        processedRaces++;
+        continue;
+      }
+
+      // 전략 평가
+      const matchedEntries = this.evaluator.evaluateRace(raceContext);
+
+      if (matchedEntries.length > 0) {
+        matchedRaces++;
+
+        // 경주 결과 가져오기
+        const result = await this.dataSource.getRaceResult(raceId);
+
+        for (const evaluation of matchedEntries) {
+          // 베팅 금액 계산
+          const betAmount = this.calculateBetAmount(
+            strategy,
+            currentCapital,
+            evaluation
+          );
+
+          // 자본 부족 체크
+          if (betAmount > currentCapital) {
+            continue;
+          }
+
+          // 베팅 처리
+          const betRecord = this.processBet(
+            raceContext,
+            evaluation,
+            result,
+            betAmount,
+            currentCapital
+          );
+
+          bets.push(betRecord);
+
+          // 자본 업데이트
+          currentCapital = betRecord.cumulativeCapital;
+
+          // 최대 낙폭 계산
+          if (currentCapital > peakCapital) {
+            peakCapital = currentCapital;
+          }
+          const drawdown = ((peakCapital - currentCapital) / peakCapital) * 100;
+          if (drawdown > maxDrawdown) {
+            maxDrawdown = drawdown;
+          }
+
+          // 연승/연패 추적
+          if (betRecord.result === 'win') {
+            if (currentStreak > 0) {
+              currentStreak++;
+            } else {
+              currentStreak = 1;
+            }
+            maxWinStreak = Math.max(maxWinStreak, currentStreak);
+          } else if (betRecord.result === 'lose') {
+            if (currentStreak < 0) {
+              currentStreak--;
+            } else {
+              currentStreak = -1;
+            }
+            maxLoseStreak = Math.max(maxLoseStreak, Math.abs(currentStreak));
+          }
+
+          // 자본 곡선 업데이트 (일별)
+          if (betRecord.raceDate !== lastEquityDate) {
+            equityCurve.push({
+              date: betRecord.raceDate,
+              capital: currentCapital,
+              drawdown,
+            });
+            lastEquityDate = betRecord.raceDate;
+          }
+        }
+      }
+
+      processedRaces++;
+
+      // 진행률 업데이트
+      if (processedRaces % PROGRESS_UPDATE_INTERVAL === 0 || processedRaces === totalRaces) {
+        const progress = Math.round((processedRaces / totalRaces) * 100);
+        await this.options.onProgress?.(
+          progress,
+          `Processing ${processedRaces}/${totalRaces} races...`
+        );
+      }
+    }
+
+    // 결과 요약 계산
+    const summary = this.calculateSummary(
+      bets,
+      totalRaces,
+      matchedRaces,
+      this.options.initialCapital,
+      currentCapital,
+      maxDrawdown,
+      maxWinStreak,
+      maxLoseStreak
+    );
+
+    const executionTimeMs = Date.now() - startTime;
+
+    return {
+      request,
+      summary,
+      bets,
+      equityCurve,
+      executedAt: new Date().toISOString(),
+      executionTimeMs,
+    };
+  }
+
+  /**
+   * 베팅 금액 계산
+   */
+  private calculateBetAmount(
+    strategy: BacktestRequest['strategy'],
+    currentCapital: number,
+    _evaluation: EvaluationResult
+  ): number {
+    const stake = strategy.stake;
+
+    // 고정 금액
+    if (stake?.fixed) {
+      return stake.fixed;
+    }
+
+    // 자본 대비 비율
+    if (stake?.percentOfBankroll) {
+      return Math.floor(currentCapital * (stake.percentOfBankroll / 100));
+    }
+
+    // Kelly Criterion (간소화된 버전)
+    if (stake?.useKelly) {
+      // 실제 Kelly는 승률과 배당률이 필요
+      // 여기서는 보수적으로 2%로 제한
+      return Math.floor(currentCapital * 0.02);
+    }
+
+    // 기본값
+    return this.options.defaultBetAmount;
+  }
+
+  /**
+   * 베팅 처리 및 결과 계산
+   */
+  private processBet(
+    race: RaceContext,
+    evaluation: EvaluationResult,
+    result: RaceResultData | null,
+    betAmount: number,
+    currentCapital: number
+  ): BetRecord {
+    const entryNo = evaluation.entryNo;
+
+    // 경주 취소된 경우
+    if (result?.canceled) {
+      return {
+        raceId: race.raceId,
+        raceDate: race.raceDate,
+        track: race.track,
+        raceNo: race.raceNo,
+        entryNo,
+        betAmount,
+        oddsAtBet: this.getEntryOdds(race, entryNo),
+        result: 'refund',
+        profit: 0,
+        cumulativeCapital: currentCapital,
+      };
+    }
+
+    // 결과가 없는 경우 (데이터 누락)
+    if (!result) {
+      return {
+        raceId: race.raceId,
+        raceDate: race.raceDate,
+        track: race.track,
+        raceNo: race.raceNo,
+        entryNo,
+        betAmount,
+        oddsAtBet: this.getEntryOdds(race, entryNo),
+        result: 'refund',
+        profit: 0,
+        cumulativeCapital: currentCapital,
+      };
+    }
+
+    const position = result.finishPositions.get(entryNo);
+    const action = evaluation.action;
+    const oddsAtBet = this.getEntryOdds(race, entryNo);
+
+    let isWin = false;
+    let payout = 0;
+
+    // 베팅 유형에 따른 승리 판정
+    if (action === 'bet_win') {
+      // 단승: 1등만
+      isWin = position === 1;
+      if (isWin) {
+        const winOdds = result.dividends.win.get(entryNo) ?? oddsAtBet;
+        payout = Math.floor(betAmount * winOdds);
+      }
+    } else if (action === 'bet_place') {
+      // 복승: 1~3등 (경마 기준)
+      isWin = position !== undefined && position <= 3;
+      if (isWin) {
+        const placeOdds = result.dividends.place?.get(entryNo) ?? oddsAtBet * 0.5;
+        payout = Math.floor(betAmount * placeOdds);
+      }
+    }
+
+    const profit = isWin ? payout - betAmount : -betAmount;
+    const newCapital = currentCapital + profit;
+
+    return {
+      raceId: race.raceId,
+      raceDate: race.raceDate,
+      track: race.track,
+      raceNo: race.raceNo,
+      entryNo,
+      betAmount,
+      oddsAtBet,
+      result: isWin ? 'win' : 'lose',
+      profit,
+      cumulativeCapital: newCapital,
+    };
+  }
+
+  /**
+   * 엔트리의 배당률 가져오기
+   */
+  private getEntryOdds(race: RaceContext, entryNo: number): number {
+    const entry = race.entries.find((e) => e.entryNo === entryNo);
+    return entry?.odds_win ?? 0;
+  }
+
+  /**
+   * 결과 요약 계산
+   */
+  private calculateSummary(
+    bets: BetRecord[],
+    totalRaces: number,
+    matchedRaces: number,
+    initialCapital: number,
+    finalCapital: number,
+    maxDrawdown: number,
+    maxWinStreak: number,
+    maxLoseStreak: number
+  ): BacktestSummary {
+    const wins = bets.filter((b) => b.result === 'win').length;
+    const losses = bets.filter((b) => b.result === 'lose').length;
+    const refunds = bets.filter((b) => b.result === 'refund').length;
+
+    const totalBets = wins + losses; // 환불 제외
+    const winRate = totalBets > 0 ? (wins / totalBets) * 100 : 0;
+
+    const totalBetAmount = bets
+      .filter((b) => b.result !== 'refund')
+      .reduce((sum, b) => sum + b.betAmount, 0);
+    const totalProfit = finalCapital - initialCapital;
+    const roi = totalBetAmount > 0 ? (totalProfit / totalBetAmount) * 100 : 0;
+    const capitalReturn = ((finalCapital - initialCapital) / initialCapital) * 100;
+
+    const avgOdds =
+      bets.length > 0
+        ? bets.reduce((sum, b) => sum + b.oddsAtBet, 0) / bets.length
+        : 0;
+    const avgBetAmount =
+      totalBets > 0
+        ? bets.filter((b) => b.result !== 'refund').reduce((sum, b) => sum + b.betAmount, 0) /
+          totalBets
+        : 0;
+
+    return {
+      totalRaces,
+      matchedRaces,
+      totalBets,
+      wins,
+      losses,
+      refunds,
+      winRate: Math.round(winRate * 100) / 100,
+      totalProfit,
+      roi: Math.round(roi * 100) / 100,
+      maxDrawdown: Math.round(maxDrawdown * 100) / 100,
+      finalCapital,
+      capitalReturn: Math.round(capitalReturn * 100) / 100,
+      avgOdds: Math.round(avgOdds * 100) / 100,
+      avgBetAmount: Math.round(avgBetAmount),
+      maxWinStreak,
+      maxLoseStreak,
+    };
+  }
+}
+
+// =============================================================================
+// Mock Data Source (for testing)
+// =============================================================================
+
+/**
+ * 테스트용 Mock 데이터 소스
+ */
+export class MockRaceDataSource implements RaceDataSource {
+  private races: Map<string, RaceContext> = new Map();
+  private results: Map<string, RaceResultData> = new Map();
+
+  addRace(race: RaceContext, result?: RaceResultData): void {
+    this.races.set(race.raceId, race);
+    if (result) {
+      this.results.set(race.raceId, result);
+    }
+  }
+
+  async getRaceIds(
+    dateFrom: string,
+    dateTo: string,
+    filters?: RaceFilters
+  ): Promise<string[]> {
+    const ids: string[] = [];
+
+    for (const [id, race] of Array.from(this.races.entries())) {
+      // 날짜 필터
+      if (race.raceDate < dateFrom || race.raceDate > dateTo) {
+        continue;
+      }
+
+      // 유형 필터
+      if (filters?.raceTypes && !filters.raceTypes.includes(race.raceType)) {
+        continue;
+      }
+
+      // 트랙 필터
+      if (filters?.tracks && !filters.tracks.includes(race.track)) {
+        continue;
+      }
+
+      ids.push(id);
+    }
+
+    return ids.sort();
+  }
+
+  async getRaceContext(raceId: string): Promise<RaceContext | null> {
+    return this.races.get(raceId) ?? null;
+  }
+
+  async getRaceResult(raceId: string): Promise<RaceResultData | null> {
+    return this.results.get(raceId) ?? null;
+  }
+}
+
+// =============================================================================
+// Factory Function
+// =============================================================================
+
+/**
+ * 백테스트 실행 편의 함수
+ */
+export async function runBacktest(
+  request: BacktestRequest,
+  dataSource: RaceDataSource,
+  options?: Partial<ExecutorOptions>
+): Promise<BacktestResult> {
+  const executor = new BacktestExecutor(request, dataSource, options);
+  return executor.execute(request);
+}

--- a/src/lib/backtest/index.ts
+++ b/src/lib/backtest/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Backtest Module
+ *
+ * 백테스팅 실행, 메트릭 계산, Job 관리를 위한 모듈
+ */
+
+// Job Types
+export type {
+  JobStatus,
+  JobPriority,
+  BacktestJob,
+  JobError,
+  JobErrorCode,
+  StoredBacktestResult,
+  CreateBacktestJobRequest,
+  CreateBacktestJobResponse,
+  GetJobStatusResponse,
+  GetJobResultResponse,
+  ListJobsRequest,
+  ListJobsResponse,
+  BacktestQuota,
+  QuotaCheckResult,
+  QStashBacktestPayload,
+  QStashWebhookHeaders,
+  WorkerContext,
+  WorkerCheckpoint,
+} from './types';
+
+// Job Constants
+export {
+  KV_KEY_PATTERNS,
+  DEFAULT_JOB_TTL_SECONDS,
+  DEFAULT_RESULT_TTL_SECONDS,
+  DEFAULT_MAX_RETRIES,
+  WORKER_TIMEOUT_MS,
+  PROGRESS_UPDATE_INTERVAL,
+  ESTIMATED_MS_PER_RACE,
+} from './types';
+
+// Executor
+export {
+  BacktestExecutor,
+  MockRaceDataSource,
+  runBacktest,
+  type ExecutorOptions,
+  type RaceDataSource,
+  type RaceFilters,
+  type RaceResultData,
+} from './executor';
+
+// Metrics
+export {
+  calculateWinRate,
+  calculateROI,
+  calculateCapitalReturn,
+  calculateMaxDrawdown,
+  calculateDrawdownPeriods,
+  calculateStreaks,
+  calculateSharpeRatio,
+  calculateProfitFactor,
+  calculateAvgWinLossRatio,
+  calculateExpectedValue,
+  calculateDailyReturns,
+  calculateMonthlyReturns,
+  calculateStdDev,
+  enhanceSummary,
+  type EnhancedBacktestSummary,
+} from './metrics';
+
+// Job Manager
+export {
+  createJob,
+  getJob,
+  updateJobStatus,
+  updateJobProgress,
+  failJob,
+  getClientJobs,
+  saveResult,
+  getResult,
+  getQuota,
+  checkQuota,
+  incrementQuotaUsage,
+  saveCheckpoint,
+  getCheckpoint,
+  deleteCheckpoint,
+  calculatePeriodDays,
+  getQueuePosition,
+} from './jobManager';

--- a/src/lib/backtest/jobManager.ts
+++ b/src/lib/backtest/jobManager.ts
@@ -1,0 +1,449 @@
+/**
+ * Backtest Job Manager
+ *
+ * Vercel KV 기반 백테스트 작업 상태 관리
+ */
+
+import { kv } from '@vercel/kv';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  BacktestJob,
+  JobStatus,
+  JobPriority,
+  JobError,
+  StoredBacktestResult,
+  BacktestQuota,
+  QuotaCheckResult,
+  KV_KEY_PATTERNS,
+  DEFAULT_JOB_TTL_SECONDS,
+  DEFAULT_RESULT_TTL_SECONDS,
+  DEFAULT_MAX_RETRIES,
+  ESTIMATED_MS_PER_RACE,
+  WorkerCheckpoint,
+} from './types';
+import type { BacktestRequest, BacktestSummary, BacktestResult } from '../strategy/types';
+import { hasBacktestAccess, getBacktestLimits, type ClientTier } from '../db/schema/clients';
+
+// =============================================================================
+// Job CRUD Operations
+// =============================================================================
+
+/**
+ * 새 백테스트 작업 생성
+ */
+export async function createJob(
+  clientId: string,
+  request: BacktestRequest,
+  priority: JobPriority = 'normal'
+): Promise<BacktestJob> {
+  const jobId = uuidv4();
+  const now = new Date().toISOString();
+
+  // 예상 경주 수 계산 (대략적 추정)
+  const dateFrom = new Date(request.dateRange.from);
+  const dateTo = new Date(request.dateRange.to);
+  const days = Math.ceil((dateTo.getTime() - dateFrom.getTime()) / (1000 * 60 * 60 * 24));
+  const estimatedRaces = days * 12; // 하루 평균 12경주 가정
+  const estimatedDuration = Math.ceil((estimatedRaces * ESTIMATED_MS_PER_RACE) / 1000);
+
+  const job: BacktestJob = {
+    id: jobId,
+    clientId,
+    status: 'pending',
+    priority,
+    request,
+    progress: 0,
+    progressMessage: 'Queued for processing',
+    createdAt: now,
+    estimatedDuration,
+    retryCount: 0,
+    maxRetries: DEFAULT_MAX_RETRIES,
+  };
+
+  // KV에 저장
+  await kv.set(KV_KEY_PATTERNS.job(jobId), job, {
+    ex: DEFAULT_JOB_TTL_SECONDS,
+  });
+
+  // 클라이언트 작업 목록에 추가
+  await kv.lpush(KV_KEY_PATTERNS.clientJobs(clientId), jobId);
+
+  return job;
+}
+
+/**
+ * 작업 조회
+ */
+export async function getJob(jobId: string): Promise<BacktestJob | null> {
+  return kv.get<BacktestJob>(KV_KEY_PATTERNS.job(jobId));
+}
+
+/**
+ * 작업 상태 업데이트
+ */
+export async function updateJobStatus(
+  jobId: string,
+  status: JobStatus,
+  updates?: Partial<BacktestJob>
+): Promise<BacktestJob | null> {
+  const job = await getJob(jobId);
+  if (!job) return null;
+
+  const updatedJob: BacktestJob = {
+    ...job,
+    ...updates,
+    status,
+  };
+
+  // 상태별 타임스탬프 업데이트
+  if (status === 'running' && !updatedJob.startedAt) {
+    updatedJob.startedAt = new Date().toISOString();
+  }
+  if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+    updatedJob.completedAt = new Date().toISOString();
+    if (updatedJob.startedAt) {
+      updatedJob.executionTimeMs =
+        new Date(updatedJob.completedAt).getTime() - new Date(updatedJob.startedAt).getTime();
+    }
+  }
+
+  await kv.set(KV_KEY_PATTERNS.job(jobId), updatedJob, {
+    ex: DEFAULT_JOB_TTL_SECONDS,
+  });
+
+  // 실행 중 작업 추적 업데이트
+  if (status === 'running') {
+    await kv.sadd(KV_KEY_PATTERNS.runningJobs(job.clientId), jobId);
+  } else if (status === 'completed' || status === 'failed' || status === 'cancelled') {
+    await kv.srem(KV_KEY_PATTERNS.runningJobs(job.clientId), jobId);
+  }
+
+  return updatedJob;
+}
+
+/**
+ * 작업 진행률 업데이트
+ */
+export async function updateJobProgress(
+  jobId: string,
+  progress: number,
+  message?: string,
+  processedRaces?: number,
+  totalRaces?: number
+): Promise<void> {
+  const job = await getJob(jobId);
+  if (!job) return;
+
+  const updatedJob: BacktestJob = {
+    ...job,
+    progress: Math.min(100, Math.max(0, progress)),
+    progressMessage: message ?? job.progressMessage,
+    processedRaces: processedRaces ?? job.processedRaces,
+    totalRaces: totalRaces ?? job.totalRaces,
+  };
+
+  await kv.set(KV_KEY_PATTERNS.job(jobId), updatedJob, {
+    ex: DEFAULT_JOB_TTL_SECONDS,
+  });
+}
+
+/**
+ * 작업 실패 처리
+ */
+export async function failJob(jobId: string, error: JobError): Promise<BacktestJob | null> {
+  const job = await getJob(jobId);
+  if (!job) return null;
+
+  // 재시도 가능한 오류인 경우 카운트 증가
+  if (error.retryable && job.retryCount < job.maxRetries) {
+    return updateJobStatus(jobId, 'pending', {
+      retryCount: job.retryCount + 1,
+      error,
+      progressMessage: `Retry ${job.retryCount + 1}/${job.maxRetries} after error`,
+    });
+  }
+
+  // 최종 실패 처리
+  return updateJobStatus(jobId, 'failed', { error });
+}
+
+/**
+ * 클라이언트의 작업 목록 조회
+ */
+export async function getClientJobs(
+  clientId: string,
+  options?: { limit?: number; offset?: number; status?: JobStatus[] }
+): Promise<{ jobs: BacktestJob[]; total: number }> {
+  const limit = options?.limit ?? 20;
+  const offset = options?.offset ?? 0;
+
+  // 클라이언트의 모든 작업 ID 조회
+  const jobIds = await kv.lrange<string>(
+    KV_KEY_PATTERNS.clientJobs(clientId),
+    offset,
+    offset + limit - 1
+  );
+  const total = await kv.llen(KV_KEY_PATTERNS.clientJobs(clientId));
+
+  if (!jobIds || jobIds.length === 0) {
+    return { jobs: [], total: 0 };
+  }
+
+  // 각 작업 정보 조회
+  const jobs: BacktestJob[] = [];
+  for (const jobId of jobIds) {
+    const job = await getJob(jobId);
+    if (job) {
+      // 상태 필터 적용
+      if (!options?.status || options.status.includes(job.status)) {
+        jobs.push(job);
+      }
+    }
+  }
+
+  return { jobs, total };
+}
+
+// =============================================================================
+// Result Storage
+// =============================================================================
+
+/**
+ * 백테스트 결과 저장
+ */
+export async function saveResult(
+  jobId: string,
+  clientId: string,
+  result: BacktestResult
+): Promise<StoredBacktestResult> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + DEFAULT_RESULT_TTL_SECONDS * 1000);
+
+  const storedResult: StoredBacktestResult = {
+    jobId,
+    clientId,
+    summary: result.summary,
+    hasFullResult: true,
+    expiresAt: expiresAt.toISOString(),
+    createdAt: now.toISOString(),
+  };
+
+  // 결과 저장 (요약 + 전체)
+  await kv.set(KV_KEY_PATTERNS.result(jobId), { ...storedResult, fullResult: result }, {
+    ex: DEFAULT_RESULT_TTL_SECONDS,
+  });
+
+  return storedResult;
+}
+
+/**
+ * 백테스트 결과 조회
+ */
+export async function getResult(jobId: string): Promise<{
+  summary: BacktestSummary;
+  fullResult?: BacktestResult;
+  expiresAt: string;
+} | null> {
+  const stored = await kv.get<StoredBacktestResult & { fullResult?: BacktestResult }>(
+    KV_KEY_PATTERNS.result(jobId)
+  );
+
+  if (!stored) return null;
+
+  return {
+    summary: stored.summary,
+    fullResult: stored.fullResult,
+    expiresAt: stored.expiresAt,
+  };
+}
+
+// =============================================================================
+// Quota Management
+// =============================================================================
+
+/**
+ * 클라이언트 할당량 조회
+ */
+export async function getQuota(clientId: string, tier: ClientTier): Promise<BacktestQuota> {
+  const limits = getBacktestLimits(tier);
+  const stored = await kv.get<{ used: number; resetAt: string }>(
+    KV_KEY_PATTERNS.quota(clientId)
+  );
+
+  // 현재 달의 시작
+  const now = new Date();
+  const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+
+  let used = 0;
+  let resetAt = nextMonthStart.toISOString();
+
+  if (stored) {
+    // 리셋 시간이 지났는지 확인
+    if (new Date(stored.resetAt) <= now) {
+      // 리셋 필요
+      used = 0;
+    } else {
+      used = stored.used;
+      resetAt = stored.resetAt;
+    }
+  }
+
+  // 실행 중인 작업 수 조회
+  const runningCount = await kv.scard(KV_KEY_PATTERNS.runningJobs(clientId)) ?? 0;
+
+  return {
+    monthlyLimit: limits.quotaMonthly,
+    used,
+    remaining: limits.quotaMonthly === -1 ? -1 : Math.max(0, limits.quotaMonthly - used),
+    resetAt,
+    concurrentLimit: limits.maxConcurrent,
+    currentRunning: runningCount,
+    maxPeriodDays: limits.maxPeriodDays,
+  };
+}
+
+/**
+ * 할당량 확인 (백테스트 실행 가능 여부)
+ */
+export async function checkQuota(
+  clientId: string,
+  tier: ClientTier,
+  requestPeriodDays: number
+): Promise<QuotaCheckResult> {
+  // 백테스트 접근 권한 확인
+  if (!hasBacktestAccess(tier)) {
+    return {
+      allowed: false,
+      reason: 'MONTHLY_LIMIT_EXCEEDED',
+      quota: {
+        monthlyLimit: 0,
+        used: 0,
+        remaining: 0,
+        resetAt: '',
+        concurrentLimit: 0,
+        currentRunning: 0,
+        maxPeriodDays: 0,
+      },
+    };
+  }
+
+  const quota = await getQuota(clientId, tier);
+
+  // 기간 제한 확인
+  if (requestPeriodDays > quota.maxPeriodDays) {
+    return {
+      allowed: false,
+      reason: 'PERIOD_LIMIT_EXCEEDED',
+      quota,
+    };
+  }
+
+  // 동시 실행 제한 확인
+  if (quota.currentRunning >= quota.concurrentLimit) {
+    return {
+      allowed: false,
+      reason: 'CONCURRENT_LIMIT_EXCEEDED',
+      quota,
+    };
+  }
+
+  // 월간 한도 확인 (무제한이 아닌 경우)
+  if (quota.monthlyLimit !== -1 && quota.used >= quota.monthlyLimit) {
+    return {
+      allowed: false,
+      reason: 'MONTHLY_LIMIT_EXCEEDED',
+      quota,
+    };
+  }
+
+  return {
+    allowed: true,
+    quota,
+  };
+}
+
+/**
+ * 할당량 사용량 증가
+ */
+export async function incrementQuotaUsage(clientId: string): Promise<void> {
+  const now = new Date();
+  const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+
+  const key = KV_KEY_PATTERNS.quota(clientId);
+  const stored = await kv.get<{ used: number; resetAt: string }>(key);
+
+  if (stored && new Date(stored.resetAt) > now) {
+    // 기존 레코드 업데이트
+    await kv.set(key, {
+      used: stored.used + 1,
+      resetAt: stored.resetAt,
+    });
+  } else {
+    // 새 레코드 생성
+    await kv.set(key, {
+      used: 1,
+      resetAt: nextMonthStart.toISOString(),
+    });
+  }
+}
+
+// =============================================================================
+// Checkpoint Management (장시간 작업용)
+// =============================================================================
+
+/**
+ * 체크포인트 저장
+ */
+export async function saveCheckpoint(
+  jobId: string,
+  checkpoint: WorkerCheckpoint
+): Promise<void> {
+  await kv.set(KV_KEY_PATTERNS.checkpoint(jobId), checkpoint, {
+    ex: 3600, // 1시간 TTL
+  });
+}
+
+/**
+ * 체크포인트 조회
+ */
+export async function getCheckpoint(jobId: string): Promise<WorkerCheckpoint | null> {
+  return kv.get<WorkerCheckpoint>(KV_KEY_PATTERNS.checkpoint(jobId));
+}
+
+/**
+ * 체크포인트 삭제
+ */
+export async function deleteCheckpoint(jobId: string): Promise<void> {
+  await kv.del(KV_KEY_PATTERNS.checkpoint(jobId));
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * 요청 기간(일) 계산
+ */
+export function calculatePeriodDays(dateRange: { from: string; to: string }): number {
+  const from = new Date(dateRange.from);
+  const to = new Date(dateRange.to);
+  return Math.ceil((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+}
+
+/**
+ * 큐 위치 조회 (대략적)
+ */
+export async function getQueuePosition(jobId: string, clientId: string): Promise<number> {
+  const jobIds = await kv.lrange<string>(KV_KEY_PATTERNS.clientJobs(clientId), 0, -1);
+  if (!jobIds) return 1;
+
+  let position = 1;
+  for (const id of jobIds) {
+    const job = await getJob(id);
+    if (job?.status === 'pending') {
+      if (job.id === jobId) return position;
+      position++;
+    }
+  }
+  return position;
+}

--- a/src/lib/backtest/metrics.ts
+++ b/src/lib/backtest/metrics.ts
@@ -1,0 +1,393 @@
+/**
+ * Backtest Metrics Calculator
+ *
+ * ROI, MDD, Sharpe Ratio 등 고급 성과 지표 계산
+ */
+
+import type { BetRecord, EquityPoint, BacktestSummary } from '../strategy/types';
+
+// =============================================================================
+// Basic Metrics
+// =============================================================================
+
+/**
+ * 승률 계산
+ */
+export function calculateWinRate(wins: number, totalBets: number): number {
+  if (totalBets === 0) return 0;
+  return (wins / totalBets) * 100;
+}
+
+/**
+ * ROI (Return on Investment) 계산
+ */
+export function calculateROI(totalProfit: number, totalBetAmount: number): number {
+  if (totalBetAmount === 0) return 0;
+  return (totalProfit / totalBetAmount) * 100;
+}
+
+/**
+ * 자본 수익률 계산
+ */
+export function calculateCapitalReturn(
+  initialCapital: number,
+  finalCapital: number
+): number {
+  if (initialCapital === 0) return 0;
+  return ((finalCapital - initialCapital) / initialCapital) * 100;
+}
+
+// =============================================================================
+// Drawdown Metrics
+// =============================================================================
+
+/**
+ * 최대 낙폭 (MDD) 계산
+ * @param equityCurve 자본 곡선
+ * @returns 최대 낙폭 (%)
+ */
+export function calculateMaxDrawdown(equityCurve: EquityPoint[]): number {
+  if (equityCurve.length === 0) return 0;
+
+  let peak = equityCurve[0].capital;
+  let maxDrawdown = 0;
+
+  for (const point of equityCurve) {
+    if (point.capital > peak) {
+      peak = point.capital;
+    }
+    const drawdown = ((peak - point.capital) / peak) * 100;
+    if (drawdown > maxDrawdown) {
+      maxDrawdown = drawdown;
+    }
+  }
+
+  return maxDrawdown;
+}
+
+/**
+ * 낙폭 기간 계산
+ */
+export function calculateDrawdownPeriods(
+  equityCurve: EquityPoint[]
+): Array<{
+  startDate: string;
+  endDate: string;
+  maxDrawdown: number;
+  duration: number;
+}> {
+  const periods: Array<{
+    startDate: string;
+    endDate: string;
+    maxDrawdown: number;
+    duration: number;
+  }> = [];
+
+  if (equityCurve.length === 0) return periods;
+
+  let peak = equityCurve[0].capital;
+  let peakDate = equityCurve[0].date;
+  let inDrawdown = false;
+  let currentDrawdownStart = '';
+  let currentMaxDrawdown = 0;
+
+  for (const point of equityCurve) {
+    if (point.capital > peak) {
+      if (inDrawdown) {
+        // 낙폭 종료
+        periods.push({
+          startDate: currentDrawdownStart,
+          endDate: point.date,
+          maxDrawdown: currentMaxDrawdown,
+          duration: calculateDaysBetween(currentDrawdownStart, point.date),
+        });
+        inDrawdown = false;
+        currentMaxDrawdown = 0;
+      }
+      peak = point.capital;
+      peakDate = point.date;
+    } else {
+      const drawdown = ((peak - point.capital) / peak) * 100;
+      if (drawdown > 0 && !inDrawdown) {
+        // 낙폭 시작
+        inDrawdown = true;
+        currentDrawdownStart = peakDate;
+      }
+      if (drawdown > currentMaxDrawdown) {
+        currentMaxDrawdown = drawdown;
+      }
+    }
+  }
+
+  // 마지막 낙폭이 진행 중인 경우
+  if (inDrawdown) {
+    const lastPoint = equityCurve[equityCurve.length - 1];
+    periods.push({
+      startDate: currentDrawdownStart,
+      endDate: lastPoint.date,
+      maxDrawdown: currentMaxDrawdown,
+      duration: calculateDaysBetween(currentDrawdownStart, lastPoint.date),
+    });
+  }
+
+  return periods;
+}
+
+// =============================================================================
+// Streak Metrics
+// =============================================================================
+
+/**
+ * 연승/연패 계산
+ */
+export function calculateStreaks(bets: BetRecord[]): {
+  maxWinStreak: number;
+  maxLoseStreak: number;
+  currentStreak: number;
+  currentStreakType: 'win' | 'lose' | 'none';
+} {
+  let maxWinStreak = 0;
+  let maxLoseStreak = 0;
+  let currentStreak = 0;
+  let currentStreakType: 'win' | 'lose' | 'none' = 'none';
+
+  for (const bet of bets) {
+    if (bet.result === 'refund') continue;
+
+    if (bet.result === 'win') {
+      if (currentStreakType === 'win') {
+        currentStreak++;
+      } else {
+        currentStreak = 1;
+        currentStreakType = 'win';
+      }
+      maxWinStreak = Math.max(maxWinStreak, currentStreak);
+    } else {
+      if (currentStreakType === 'lose') {
+        currentStreak++;
+      } else {
+        currentStreak = 1;
+        currentStreakType = 'lose';
+      }
+      maxLoseStreak = Math.max(maxLoseStreak, currentStreak);
+    }
+  }
+
+  return {
+    maxWinStreak,
+    maxLoseStreak,
+    currentStreak,
+    currentStreakType,
+  };
+}
+
+// =============================================================================
+// Advanced Metrics
+// =============================================================================
+
+/**
+ * Sharpe Ratio 계산 (간소화 버전)
+ * @param returns 일별 수익률 배열
+ * @param riskFreeRate 무위험 수익률 (연간, 기본 0)
+ * @returns Sharpe Ratio
+ */
+export function calculateSharpeRatio(
+  returns: number[],
+  riskFreeRate: number = 0
+): number {
+  if (returns.length === 0) return 0;
+
+  const avgReturn = returns.reduce((a, b) => a + b, 0) / returns.length;
+  const stdDev = calculateStdDev(returns);
+
+  if (stdDev === 0) return 0;
+
+  // 일간 무위험 수익률로 변환 (연 252 거래일 가정)
+  const dailyRiskFree = riskFreeRate / 252;
+
+  return ((avgReturn - dailyRiskFree) / stdDev) * Math.sqrt(252);
+}
+
+/**
+ * Profit Factor 계산
+ * 총 수익 / 총 손실
+ */
+export function calculateProfitFactor(bets: BetRecord[]): number {
+  const totalWins = bets
+    .filter((b) => b.result === 'win')
+    .reduce((sum, b) => sum + b.profit, 0);
+  const totalLosses = Math.abs(
+    bets.filter((b) => b.result === 'lose').reduce((sum, b) => sum + b.profit, 0)
+  );
+
+  if (totalLosses === 0) return totalWins > 0 ? Infinity : 0;
+  return totalWins / totalLosses;
+}
+
+/**
+ * 평균 이익 / 평균 손실 비율
+ */
+export function calculateAvgWinLossRatio(bets: BetRecord[]): number {
+  const wins = bets.filter((b) => b.result === 'win');
+  const losses = bets.filter((b) => b.result === 'lose');
+
+  if (wins.length === 0 || losses.length === 0) return 0;
+
+  const avgWin = wins.reduce((sum, b) => sum + b.profit, 0) / wins.length;
+  const avgLoss = Math.abs(losses.reduce((sum, b) => sum + b.profit, 0) / losses.length);
+
+  if (avgLoss === 0) return avgWin > 0 ? Infinity : 0;
+  return avgWin / avgLoss;
+}
+
+/**
+ * 기대값 (Expected Value) 계산
+ */
+export function calculateExpectedValue(
+  winRate: number,
+  avgWin: number,
+  avgLoss: number
+): number {
+  const winProb = winRate / 100;
+  const loseProb = 1 - winProb;
+  return winProb * avgWin - loseProb * avgLoss;
+}
+
+// =============================================================================
+// Daily Returns
+// =============================================================================
+
+/**
+ * 일별 수익률 계산
+ */
+export function calculateDailyReturns(equityCurve: EquityPoint[]): number[] {
+  if (equityCurve.length < 2) return [];
+
+  const returns: number[] = [];
+  for (let i = 1; i < equityCurve.length; i++) {
+    const prevCapital = equityCurve[i - 1].capital;
+    const currentCapital = equityCurve[i].capital;
+    if (prevCapital > 0) {
+      returns.push((currentCapital - prevCapital) / prevCapital);
+    }
+  }
+
+  return returns;
+}
+
+/**
+ * 월별 수익률 계산
+ */
+export function calculateMonthlyReturns(
+  bets: BetRecord[]
+): Map<string, { profit: number; bets: number; winRate: number }> {
+  const monthly = new Map<string, { profit: number; bets: number; wins: number }>();
+
+  for (const bet of bets) {
+    if (bet.result === 'refund') continue;
+
+    const month = bet.raceDate.slice(0, 7); // YYYY-MM
+    const current = monthly.get(month) ?? { profit: 0, bets: 0, wins: 0 };
+
+    current.profit += bet.profit;
+    current.bets++;
+    if (bet.result === 'win') current.wins++;
+
+    monthly.set(month, current);
+  }
+
+  // 승률 계산 추가
+  const result = new Map<string, { profit: number; bets: number; winRate: number }>();
+  for (const [month, data] of Array.from(monthly.entries())) {
+    result.set(month, {
+      profit: data.profit,
+      bets: data.bets,
+      winRate: data.bets > 0 ? (data.wins / data.bets) * 100 : 0,
+    });
+  }
+
+  return result;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * 표준편차 계산
+ */
+export function calculateStdDev(values: number[]): number {
+  if (values.length === 0) return 0;
+
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const squaredDiffs = values.map((x) => Math.pow(x - mean, 2));
+  const variance = squaredDiffs.reduce((a, b) => a + b, 0) / values.length;
+
+  return Math.sqrt(variance);
+}
+
+/**
+ * 두 날짜 사이의 일수 계산
+ */
+function calculateDaysBetween(dateFrom: string, dateTo: string): number {
+  const from = new Date(dateFrom);
+  const to = new Date(dateTo);
+  return Math.ceil((to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+// =============================================================================
+// Summary Enhancement
+// =============================================================================
+
+/**
+ * 기존 요약에 고급 메트릭 추가
+ */
+export interface EnhancedBacktestSummary extends BacktestSummary {
+  sharpeRatio: number;
+  profitFactor: number;
+  avgWinLossRatio: number;
+  expectedValue: number;
+  monthlyReturns: Array<{
+    month: string;
+    profit: number;
+    bets: number;
+    winRate: number;
+  }>;
+}
+
+/**
+ * 고급 메트릭 계산 및 요약 확장
+ */
+export function enhanceSummary(
+  summary: BacktestSummary,
+  bets: BetRecord[],
+  equityCurve: EquityPoint[]
+): EnhancedBacktestSummary {
+  const dailyReturns = calculateDailyReturns(equityCurve);
+  const sharpeRatio = calculateSharpeRatio(dailyReturns);
+  const profitFactor = calculateProfitFactor(bets);
+  const avgWinLossRatio = calculateAvgWinLossRatio(bets);
+
+  const wins = bets.filter((b) => b.result === 'win');
+  const losses = bets.filter((b) => b.result === 'lose');
+  const avgWin = wins.length > 0 ? wins.reduce((s, b) => s + b.profit, 0) / wins.length : 0;
+  const avgLoss =
+    losses.length > 0
+      ? Math.abs(losses.reduce((s, b) => s + b.profit, 0)) / losses.length
+      : 0;
+  const expectedValue = calculateExpectedValue(summary.winRate, avgWin, avgLoss);
+
+  const monthlyMap = calculateMonthlyReturns(bets);
+  const monthlyReturns = Array.from(monthlyMap.entries())
+    .map(([month, data]) => ({ month, ...data }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  return {
+    ...summary,
+    sharpeRatio: Math.round(sharpeRatio * 100) / 100,
+    profitFactor: Math.round(profitFactor * 100) / 100,
+    avgWinLossRatio: Math.round(avgWinLossRatio * 100) / 100,
+    expectedValue: Math.round(expectedValue),
+    monthlyReturns,
+  };
+}

--- a/src/lib/backtest/types.ts
+++ b/src/lib/backtest/types.ts
@@ -1,0 +1,466 @@
+/**
+ * Backtest Job Types
+ *
+ * QStash + Vercel KV 기반 비동기 백테스팅 작업 관리
+ */
+
+import type { BacktestRequest, BacktestResult, BacktestSummary } from '../strategy/types';
+
+// =============================================================================
+// Job Status & State
+// =============================================================================
+
+/**
+ * 백테스트 작업 상태
+ */
+export type JobStatus =
+  | 'pending' // 대기 중 (큐에 등록됨)
+  | 'running' // 실행 중
+  | 'completed' // 완료
+  | 'failed' // 실패
+  | 'cancelled'; // 취소됨
+
+/**
+ * 백테스트 작업 우선순위
+ */
+export type JobPriority = 'low' | 'normal' | 'high';
+
+// =============================================================================
+// Job Entity
+// =============================================================================
+
+/**
+ * 백테스트 작업 엔티티
+ */
+export interface BacktestJob {
+  /** 고유 작업 ID (UUID) */
+  id: string;
+
+  /** 소유 클라이언트 ID */
+  clientId: string;
+
+  /** 작업 상태 */
+  status: JobStatus;
+
+  /** 우선순위 */
+  priority: JobPriority;
+
+  /** 백테스트 요청 데이터 */
+  request: BacktestRequest;
+
+  /** 진행률 (0-100) */
+  progress: number;
+
+  /** 진행 상태 메시지 */
+  progressMessage?: string;
+
+  /** 처리된 경주 수 */
+  processedRaces?: number;
+
+  /** 총 대상 경주 수 */
+  totalRaces?: number;
+
+  /** 생성 시각 */
+  createdAt: string;
+
+  /** 시작 시각 */
+  startedAt?: string;
+
+  /** 완료 시각 */
+  completedAt?: string;
+
+  /** 예상 완료 시간 (초) */
+  estimatedDuration?: number;
+
+  /** 실제 실행 시간 (ms) */
+  executionTimeMs?: number;
+
+  /** 오류 정보 (실패 시) */
+  error?: JobError;
+
+  /** QStash 메시지 ID */
+  qstashMessageId?: string;
+
+  /** 재시도 횟수 */
+  retryCount: number;
+
+  /** 최대 재시도 횟수 */
+  maxRetries: number;
+}
+
+/**
+ * 작업 오류 정보
+ */
+export interface JobError {
+  code: JobErrorCode;
+  message: string;
+  details?: string;
+  stack?: string;
+  retryable: boolean;
+}
+
+/**
+ * 작업 오류 코드
+ */
+export type JobErrorCode =
+  | 'VALIDATION_ERROR' // 입력 검증 실패
+  | 'QUOTA_EXCEEDED' // 할당량 초과
+  | 'DATA_NOT_FOUND' // 데이터 없음
+  | 'TIMEOUT' // 시간 초과
+  | 'INTERNAL_ERROR' // 내부 오류
+  | 'CANCELLED'; // 사용자 취소
+
+// =============================================================================
+// Job Result Storage
+// =============================================================================
+
+/**
+ * 저장된 백테스트 결과 (Vercel KV)
+ */
+export interface StoredBacktestResult {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 클라이언트 ID */
+  clientId: string;
+
+  /** 결과 요약 */
+  summary: BacktestSummary;
+
+  /** 결과 데이터 위치 (대용량은 별도 저장) */
+  resultDataUrl?: string;
+
+  /** 전체 결과 포함 여부 */
+  hasFullResult: boolean;
+
+  /** 만료 시각 (TTL) */
+  expiresAt: string;
+
+  /** 생성 시각 */
+  createdAt: string;
+}
+
+// =============================================================================
+// API Request/Response Types
+// =============================================================================
+
+/**
+ * 백테스트 작업 생성 요청
+ */
+export interface CreateBacktestJobRequest {
+  /** 백테스트 요청 */
+  request: BacktestRequest;
+
+  /** 우선순위 (선택) */
+  priority?: JobPriority;
+
+  /** 웹훅 URL (완료 시 알림) */
+  webhookUrl?: string;
+}
+
+/**
+ * 백테스트 작업 생성 응답
+ */
+export interface CreateBacktestJobResponse {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 초기 상태 */
+  status: JobStatus;
+
+  /** 예상 완료 시간 (초) */
+  estimatedDuration: number;
+
+  /** 큐 위치 */
+  queuePosition: number;
+
+  /** 결과 조회 URL */
+  statusUrl: string;
+
+  /** 결과 조회 URL */
+  resultUrl: string;
+}
+
+/**
+ * 작업 상태 조회 응답
+ */
+export interface GetJobStatusResponse {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 현재 상태 */
+  status: JobStatus;
+
+  /** 진행률 (0-100) */
+  progress: number;
+
+  /** 진행 메시지 */
+  progressMessage?: string;
+
+  /** 처리 현황 */
+  processed?: {
+    races: number;
+    total: number;
+  };
+
+  /** 오류 (실패 시) */
+  error?: {
+    code: JobErrorCode;
+    message: string;
+  };
+
+  /** 예상 남은 시간 (초) */
+  estimatedRemainingSeconds?: number;
+
+  /** 생성 시각 */
+  createdAt: string;
+
+  /** 시작 시각 */
+  startedAt?: string;
+
+  /** 완료 시각 */
+  completedAt?: string;
+}
+
+/**
+ * 작업 결과 조회 응답
+ */
+export interface GetJobResultResponse {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 상태 (completed만 결과 포함) */
+  status: JobStatus;
+
+  /** 결과 요약 */
+  summary?: BacktestSummary;
+
+  /** 전체 결과 (옵션) */
+  fullResult?: BacktestResult;
+
+  /** 전체 결과 다운로드 URL */
+  downloadUrl?: string;
+
+  /** 결과 만료 시각 */
+  expiresAt?: string;
+}
+
+/**
+ * 작업 목록 조회 요청
+ */
+export interface ListJobsRequest {
+  /** 상태 필터 */
+  status?: JobStatus | JobStatus[];
+
+  /** 페이지 번호 (1부터) */
+  page?: number;
+
+  /** 페이지 크기 */
+  limit?: number;
+
+  /** 정렬 기준 */
+  sortBy?: 'createdAt' | 'status';
+
+  /** 정렬 방향 */
+  sortOrder?: 'asc' | 'desc';
+}
+
+/**
+ * 작업 목록 조회 응답
+ */
+export interface ListJobsResponse {
+  /** 작업 목록 */
+  jobs: Array<{
+    jobId: string;
+    status: JobStatus;
+    strategyName: string;
+    dateRange: { from: string; to: string };
+    progress: number;
+    createdAt: string;
+    completedAt?: string;
+  }>;
+
+  /** 페이지네이션 */
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+// =============================================================================
+// Quota Management
+// =============================================================================
+
+/**
+ * 백테스트 할당량 정보
+ */
+export interface BacktestQuota {
+  /** 월간 한도 (-1 = 무제한) */
+  monthlyLimit: number;
+
+  /** 사용량 */
+  used: number;
+
+  /** 남은 횟수 (-1 = 무제한) */
+  remaining: number;
+
+  /** 리셋 시각 */
+  resetAt: string;
+
+  /** 동시 실행 한도 */
+  concurrentLimit: number;
+
+  /** 현재 실행 중인 작업 수 */
+  currentRunning: number;
+
+  /** 최대 백테스트 기간 (일) */
+  maxPeriodDays: number;
+}
+
+/**
+ * 할당량 확인 결과
+ */
+export interface QuotaCheckResult {
+  /** 실행 가능 여부 */
+  allowed: boolean;
+
+  /** 거부 사유 */
+  reason?: 'MONTHLY_LIMIT_EXCEEDED' | 'CONCURRENT_LIMIT_EXCEEDED' | 'PERIOD_LIMIT_EXCEEDED';
+
+  /** 현재 할당량 정보 */
+  quota: BacktestQuota;
+}
+
+// =============================================================================
+// QStash Integration
+// =============================================================================
+
+/**
+ * QStash 메시지 페이로드
+ */
+export interface QStashBacktestPayload {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 클라이언트 ID */
+  clientId: string;
+
+  /** 백테스트 요청 */
+  request: BacktestRequest;
+
+  /** 재시도 컨텍스트 */
+  retryContext?: {
+    attempt: number;
+    previousError?: string;
+  };
+}
+
+/**
+ * QStash 웹훅 헤더
+ */
+export interface QStashWebhookHeaders {
+  'upstash-message-id': string;
+  'upstash-retried': string;
+  'upstash-schedule-id'?: string;
+  'upstash-signature': string;
+}
+
+// =============================================================================
+// Worker Types
+// =============================================================================
+
+/**
+ * 워커 실행 컨텍스트
+ */
+export interface WorkerContext {
+  /** 작업 ID */
+  jobId: string;
+
+  /** 클라이언트 ID */
+  clientId: string;
+
+  /** 시작 시각 */
+  startTime: number;
+
+  /** 타임아웃 (ms) */
+  timeout: number;
+
+  /** 진행률 업데이트 함수 */
+  updateProgress: (progress: number, message?: string) => Promise<void>;
+
+  /** 체크포인트 저장 함수 (장시간 작업용) */
+  saveCheckpoint?: (checkpoint: WorkerCheckpoint) => Promise<void>;
+}
+
+/**
+ * 워커 체크포인트 (장시간 작업 재개용)
+ */
+export interface WorkerCheckpoint {
+  /** 마지막 처리된 경주 ID */
+  lastProcessedRaceId: string;
+
+  /** 처리된 경주 수 */
+  processedCount: number;
+
+  /** 중간 결과 */
+  partialResults: {
+    bets: number;
+    wins: number;
+    totalProfit: number;
+    currentCapital: number;
+  };
+
+  /** 체크포인트 시각 */
+  savedAt: string;
+}
+
+// =============================================================================
+// Vercel KV Key Patterns
+// =============================================================================
+
+/**
+ * Vercel KV 키 패턴
+ */
+export const KV_KEY_PATTERNS = {
+  /** 작업 정보: backtest:job:{jobId} */
+  job: (jobId: string) => `backtest:job:${jobId}`,
+
+  /** 작업 결과: backtest:result:{jobId} */
+  result: (jobId: string) => `backtest:result:${jobId}`,
+
+  /** 클라이언트 할당량: backtest:quota:{clientId} */
+  quota: (clientId: string) => `backtest:quota:${clientId}`,
+
+  /** 클라이언트 작업 목록: backtest:jobs:{clientId} */
+  clientJobs: (clientId: string) => `backtest:jobs:${clientId}`,
+
+  /** 실행 중인 작업: backtest:running:{clientId} */
+  runningJobs: (clientId: string) => `backtest:running:${clientId}`,
+
+  /** 워커 체크포인트: backtest:checkpoint:{jobId} */
+  checkpoint: (jobId: string) => `backtest:checkpoint:${jobId}`,
+} as const;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** 기본 작업 TTL (7일) */
+export const DEFAULT_JOB_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/** 결과 TTL (30일) */
+export const DEFAULT_RESULT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/** 기본 최대 재시도 */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/** 워커 타임아웃 (55초 - Vercel 제한 60초보다 약간 작게) */
+export const WORKER_TIMEOUT_MS = 55 * 1000;
+
+/** 진행률 업데이트 간격 (경주 수) */
+export const PROGRESS_UPDATE_INTERVAL = 10;
+
+/** 예상 경주당 처리 시간 (ms) */
+export const ESTIMATED_MS_PER_RACE = 50;

--- a/src/lib/strategy/evaluator.test.ts
+++ b/src/lib/strategy/evaluator.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Strategy Evaluator Tests
+ */
+
+import {
+  StrategyEvaluator,
+  evaluateRace,
+  calculateOddsDrift,
+  calculateOddsStdDev,
+  calculatePoolPercentage,
+  type RaceContext,
+  type EntryContext,
+} from './evaluator';
+import type { StrategyDefinition } from './types';
+
+describe('StrategyEvaluator', () => {
+  const baseStrategy: StrategyDefinition = {
+    id: 'test-strategy',
+    name: '테스트 전략',
+    version: '1.0.0',
+    conditions: [
+      {
+        field: 'odds_drift_pct',
+        operator: 'lt',
+        value: -20,
+      },
+      {
+        field: 'popularity_rank',
+        operator: 'lte',
+        value: 3,
+      },
+    ],
+    action: 'bet_win',
+    metadata: {
+      author: 'test',
+      createdAt: '2025-01-01T00:00:00Z',
+    },
+  };
+
+  const baseRace: RaceContext = {
+    raceId: 'horse-seoul-1-20250101',
+    raceDate: '2025-01-01',
+    raceNo: 1,
+    track: 'seoul',
+    raceType: 'horse',
+    entries: [
+      {
+        raceId: 'horse-seoul-1-20250101',
+        entryNo: 1,
+        odds_win: 2.5,
+        odds_drift_pct: -25, // 25% 하락
+        popularity_rank: 1,
+        pool_total: 100000000,
+        pool_win_pct: 30,
+      },
+      {
+        raceId: 'horse-seoul-1-20250101',
+        entryNo: 2,
+        odds_win: 5.0,
+        odds_drift_pct: -10, // 10% 하락 (조건 미충족)
+        popularity_rank: 2,
+        pool_total: 100000000,
+        pool_win_pct: 20,
+      },
+      {
+        raceId: 'horse-seoul-1-20250101',
+        entryNo: 3,
+        odds_win: 3.0,
+        odds_drift_pct: -30, // 30% 하락
+        popularity_rank: 5, // 인기순위 미충족
+        pool_total: 100000000,
+        pool_win_pct: 15,
+      },
+    ],
+  };
+
+  describe('evaluateRace', () => {
+    it('should return matching entries', () => {
+      const results = evaluateRace(baseStrategy, baseRace);
+
+      // 엔트리 1만 모든 조건 충족 (drift -25% < -20%, rank 1 <= 3)
+      expect(results).toHaveLength(1);
+      expect(results[0].entryNo).toBe(1);
+      expect(results[0].matched).toBe(true);
+      expect(results[0].action).toBe('bet_win');
+    });
+
+    it('should return empty when no entries match', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [
+          {
+            field: 'odds_drift_pct',
+            operator: 'lt',
+            value: -50, // 아무도 50% 이상 하락 안함
+          },
+        ],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(0);
+    });
+
+    it('should apply race type filter', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        filters: {
+          raceTypes: ['cycle'], // cycle만 허용
+        },
+      };
+
+      const results = evaluateRace(strategy, baseRace); // horse 경주
+      expect(results).toHaveLength(0);
+    });
+
+    it('should apply track filter', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        filters: {
+          tracks: ['busan'], // busan만 허용
+        },
+      };
+
+      const results = evaluateRace(strategy, baseRace); // seoul 경주
+      expect(results).toHaveLength(0);
+    });
+
+    it('should apply minEntries filter', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        filters: {
+          minEntries: 10, // 최소 10마리
+        },
+      };
+
+      const results = evaluateRace(strategy, baseRace); // 3마리
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('evaluateEntry', () => {
+    it('should evaluate all conditions', () => {
+      const evaluator = new StrategyEvaluator(baseStrategy);
+      const result = evaluator.evaluateEntry(baseRace.entries[0], baseRace);
+
+      expect(result.conditionResults).toHaveLength(2);
+      expect(result.conditionResults[0].field).toBe('odds_drift_pct');
+      expect(result.conditionResults[0].matched).toBe(true);
+      expect(result.conditionResults[1].field).toBe('popularity_rank');
+      expect(result.conditionResults[1].matched).toBe(true);
+    });
+
+    it('should stop on first failed condition', () => {
+      const evaluator = new StrategyEvaluator(baseStrategy);
+      const result = evaluator.evaluateEntry(baseRace.entries[1], baseRace);
+
+      // drift 조건 실패 후 중단
+      expect(result.matched).toBe(false);
+      expect(result.conditionResults).toHaveLength(1);
+      expect(result.conditionResults[0].matched).toBe(false);
+    });
+
+    it('should handle missing field values', () => {
+      const evaluator = new StrategyEvaluator(baseStrategy);
+      const entryWithMissingData: EntryContext = {
+        raceId: 'test',
+        entryNo: 1,
+        // odds_drift_pct is missing
+      };
+
+      const result = evaluator.evaluateEntry(entryWithMissingData, baseRace);
+      expect(result.matched).toBe(false);
+      expect(result.conditionResults[0].error).toContain('no value');
+    });
+  });
+
+  describe('condition operators', () => {
+    it('should handle eq operator', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'popularity_rank', operator: 'eq', value: 1 }],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(1);
+      expect(results[0].entryNo).toBe(1);
+    });
+
+    it('should handle ne operator', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'popularity_rank', operator: 'ne', value: 1 }],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.entryNo)).toEqual([2, 3]);
+    });
+
+    it('should handle between operator', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'odds_win', operator: 'between', value: [2.0, 4.0] }],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.entryNo).sort()).toEqual([1, 3]);
+    });
+
+    it('should handle in operator', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'popularity_rank', operator: 'in', value: [1, 2] }],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(2);
+      expect(results.map((r) => r.entryNo).sort()).toEqual([1, 2]);
+    });
+  });
+
+  describe('time reference', () => {
+    it('should use first odds when timeRef is first', () => {
+      const entryWithTimeline: EntryContext = {
+        raceId: 'test',
+        entryNo: 1,
+        odds_win: 3.0, // current
+        popularity_rank: 1,
+        oddsTimeline: [
+          { time: new Date('2025-01-01T10:00:00Z'), odds_win: 5.0 },
+          { time: new Date('2025-01-01T11:00:00Z'), odds_win: 4.0 },
+          { time: new Date('2025-01-01T12:00:00Z'), odds_win: 3.0 },
+        ],
+      };
+
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'odds_win', operator: 'eq', value: 5.0, timeRef: 'first' }],
+      };
+
+      const evaluator = new StrategyEvaluator(strategy);
+      const result = evaluator.evaluateEntry(
+        entryWithTimeline,
+        { ...baseRace, entries: [entryWithTimeline] }
+      );
+
+      expect(result.matched).toBe(true);
+      expect(result.conditionResults[0].actualValue).toBe(5.0);
+    });
+
+    it('should use last odds when timeRef is last', () => {
+      const entryWithTimeline: EntryContext = {
+        raceId: 'test',
+        entryNo: 1,
+        odds_win: 3.0,
+        popularity_rank: 1,
+        oddsTimeline: [
+          { time: new Date('2025-01-01T10:00:00Z'), odds_win: 5.0 },
+          { time: new Date('2025-01-01T11:00:00Z'), odds_win: 4.0 },
+          { time: new Date('2025-01-01T12:00:00Z'), odds_win: 3.0 },
+        ],
+      };
+
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'odds_win', operator: 'eq', value: 3.0, timeRef: 'last' }],
+      };
+
+      const evaluator = new StrategyEvaluator(strategy);
+      const result = evaluator.evaluateEntry(
+        entryWithTimeline,
+        { ...baseRace, entries: [entryWithTimeline] }
+      );
+
+      expect(result.matched).toBe(true);
+      expect(result.conditionResults[0].actualValue).toBe(3.0);
+    });
+  });
+
+  describe('entry_count field', () => {
+    it('should evaluate entry_count from race entries', () => {
+      const strategy: StrategyDefinition = {
+        ...baseStrategy,
+        conditions: [{ field: 'entry_count', operator: 'eq', value: 3 }],
+      };
+
+      const results = evaluateRace(strategy, baseRace);
+      expect(results).toHaveLength(3); // 모든 엔트리가 매칭
+    });
+  });
+});
+
+describe('Helper Functions', () => {
+  describe('calculateOddsDrift', () => {
+    it('should calculate positive drift', () => {
+      const drift = calculateOddsDrift(2.0, 3.0);
+      expect(drift).toBe(50); // +50%
+    });
+
+    it('should calculate negative drift', () => {
+      const drift = calculateOddsDrift(4.0, 2.0);
+      expect(drift).toBe(-50); // -50%
+    });
+
+    it('should handle zero first odds', () => {
+      const drift = calculateOddsDrift(0, 2.0);
+      expect(drift).toBe(0);
+    });
+  });
+
+  describe('calculateOddsStdDev', () => {
+    it('should calculate standard deviation', () => {
+      const stddev = calculateOddsStdDev([2, 4, 4, 4, 5, 5, 7, 9]);
+      expect(stddev).toBeCloseTo(2.0, 1);
+    });
+
+    it('should return 0 for empty array', () => {
+      const stddev = calculateOddsStdDev([]);
+      expect(stddev).toBe(0);
+    });
+
+    it('should return 0 for single value', () => {
+      const stddev = calculateOddsStdDev([5]);
+      expect(stddev).toBe(0);
+    });
+  });
+
+  describe('calculatePoolPercentage', () => {
+    it('should calculate percentage', () => {
+      const pct = calculatePoolPercentage(30000000, 100000000);
+      expect(pct).toBe(30);
+    });
+
+    it('should handle zero total', () => {
+      const pct = calculatePoolPercentage(1000, 0);
+      expect(pct).toBe(0);
+    });
+  });
+});
+
+describe('StrategyEvaluator.getSupportedFields', () => {
+  it('should return Phase 0 fields by default', () => {
+    const fields = StrategyEvaluator.getSupportedFields(0);
+    expect(fields).toContain('odds_win');
+    expect(fields).toContain('odds_drift_pct');
+    expect(fields).toContain('popularity_rank');
+    expect(fields).not.toContain('horse_rating'); // Phase 1
+  });
+
+  it('should return Phase 0 and 1 fields', () => {
+    const fields = StrategyEvaluator.getSupportedFields(1);
+    expect(fields).toContain('odds_win');
+    expect(fields).toContain('horse_rating');
+    expect(fields).toContain('burden_weight');
+  });
+});

--- a/src/lib/strategy/evaluator.ts
+++ b/src/lib/strategy/evaluator.ts
@@ -1,0 +1,451 @@
+/**
+ * Strategy Evaluator
+ *
+ * 전략 조건을 실제 데이터와 대조하여 평가하는 엔진
+ * 보안: 모든 필드/연산자는 whitelist 기반으로 처리
+ */
+
+import type {
+  StrategyDefinition,
+  StrategyCondition,
+  ConditionField,
+  ConditionOperator,
+  TimeReference,
+  BetAction,
+} from './types';
+import { FIELD_METADATA } from './types';
+
+// =============================================================================
+// Data Context Types
+// =============================================================================
+
+/**
+ * 단일 경주 엔트리의 평가 데이터 컨텍스트
+ */
+export interface EntryContext {
+  // 식별자
+  raceId: string;
+  entryNo: number;
+
+  // 배당률 관련 (Phase 0)
+  odds_win?: number;
+  odds_place?: number;
+  odds_drift_pct?: number; // (last - first) / first * 100
+  odds_stddev?: number;
+
+  // 수급 관련 (Phase 0)
+  popularity_rank?: number;
+  pool_total?: number;
+  pool_win_pct?: number;
+
+  // 경주마 정보 (Phase 1)
+  horse_rating?: number;
+  burden_weight?: number;
+  entry_count?: number;
+
+  // 시계열 데이터 (시간 참조용)
+  oddsTimeline?: Array<{
+    time: Date;
+    odds_win: number;
+    odds_place?: number;
+  }>;
+}
+
+/**
+ * 경주 컨텍스트 (모든 엔트리 포함)
+ */
+export interface RaceContext {
+  raceId: string;
+  raceDate: string;
+  raceNo: number;
+  track: string;
+  raceType: 'horse' | 'cycle' | 'boat';
+  grade?: string;
+  startTime?: Date;
+  entries: EntryContext[];
+}
+
+/**
+ * 평가 결과
+ */
+export interface EvaluationResult {
+  raceId: string;
+  entryNo: number;
+  matched: boolean;
+  action: BetAction;
+  conditionResults: ConditionResult[];
+  confidence?: number; // 조건 매칭 강도 (추후)
+}
+
+/**
+ * 개별 조건 평가 결과
+ */
+export interface ConditionResult {
+  field: ConditionField;
+  operator: ConditionOperator;
+  expectedValue: unknown;
+  actualValue: unknown;
+  matched: boolean;
+  error?: string;
+}
+
+// =============================================================================
+// Strategy Evaluator Class
+// =============================================================================
+
+/**
+ * 전략 평가기
+ */
+export class StrategyEvaluator {
+  private strategy: StrategyDefinition;
+
+  constructor(strategy: StrategyDefinition) {
+    this.strategy = strategy;
+  }
+
+  /**
+   * 단일 경주의 모든 엔트리에 대해 전략 평가
+   * @returns 조건을 만족하는 엔트리들의 평가 결과
+   */
+  evaluateRace(race: RaceContext): EvaluationResult[] {
+    const results: EvaluationResult[] = [];
+
+    // 필터 조건 확인
+    if (!this.passesFilters(race)) {
+      return results;
+    }
+
+    // 각 엔트리에 대해 조건 평가
+    for (const entry of race.entries) {
+      const result = this.evaluateEntry(entry, race);
+      if (result.matched) {
+        results.push(result);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * 단일 엔트리에 대해 모든 조건 평가
+   */
+  evaluateEntry(entry: EntryContext, race: RaceContext): EvaluationResult {
+    const conditionResults: ConditionResult[] = [];
+    let allMatched = true;
+
+    // entry_count는 경주 레벨 데이터이므로 추가
+    const entryWithRaceData: EntryContext = {
+      ...entry,
+      entry_count: race.entries.length,
+    };
+
+    // 모든 조건 평가 (AND 조합)
+    for (const condition of this.strategy.conditions) {
+      const result = this.evaluateCondition(condition, entryWithRaceData);
+      conditionResults.push(result);
+
+      if (!result.matched) {
+        allMatched = false;
+        // 하나라도 실패하면 더 이상 평가할 필요 없음
+        break;
+      }
+    }
+
+    return {
+      raceId: entry.raceId,
+      entryNo: entry.entryNo,
+      matched: allMatched,
+      action: allMatched ? this.strategy.action : 'skip',
+      conditionResults,
+    };
+  }
+
+  /**
+   * 단일 조건 평가
+   */
+  private evaluateCondition(
+    condition: StrategyCondition,
+    entry: EntryContext
+  ): ConditionResult {
+    const { field, operator, value, timeRef } = condition;
+
+    // 필드 값 추출
+    const actualValue = this.getFieldValue(field, entry, timeRef);
+
+    // 값이 없는 경우
+    if (actualValue === undefined || actualValue === null) {
+      return {
+        field,
+        operator,
+        expectedValue: value,
+        actualValue: null,
+        matched: false,
+        error: `Field '${field}' has no value`,
+      };
+    }
+
+    // 연산자별 비교
+    const matched = this.compareValues(operator, actualValue, value);
+
+    return {
+      field,
+      operator,
+      expectedValue: value,
+      actualValue,
+      matched,
+    };
+  }
+
+  /**
+   * 필드 값 추출 (시간 참조 포함)
+   */
+  private getFieldValue(
+    field: ConditionField,
+    entry: EntryContext,
+    timeRef?: TimeReference
+  ): number | undefined {
+    // 시계열 데이터가 있고 시간 참조가 지정된 경우
+    if (timeRef && entry.oddsTimeline && entry.oddsTimeline.length > 0) {
+      return this.getTimeRefValue(field, entry, timeRef);
+    }
+
+    // 직접 필드 값 반환
+    return entry[field] as number | undefined;
+  }
+
+  /**
+   * 시간 참조 기반 값 추출
+   */
+  private getTimeRefValue(
+    field: ConditionField,
+    entry: EntryContext,
+    timeRef: TimeReference
+  ): number | undefined {
+    const timeline = entry.oddsTimeline;
+    if (!timeline || timeline.length === 0) {
+      return undefined;
+    }
+
+    // 시간순 정렬
+    const sorted = [...timeline].sort((a, b) => a.time.getTime() - b.time.getTime());
+
+    switch (timeRef) {
+      case 'first':
+        return this.getOddsFromSnapshot(sorted[0], field);
+
+      case 'last':
+        return this.getOddsFromSnapshot(sorted[sorted.length - 1], field);
+
+      case 'T-5m':
+      case 'T-15m':
+      case 'T-30m':
+      case 'T-60m': {
+        // T-Xm 형식에서 분 추출
+        const minutes = parseInt(timeRef.slice(2, -1), 10);
+        return this.findClosestSnapshot(sorted, minutes, field);
+      }
+
+      default:
+        return entry[field] as number | undefined;
+    }
+  }
+
+  /**
+   * 스냅샷에서 배당률 필드 추출
+   */
+  private getOddsFromSnapshot(
+    snapshot: { odds_win: number; odds_place?: number },
+    field: ConditionField
+  ): number | undefined {
+    if (field === 'odds_win') return snapshot.odds_win;
+    if (field === 'odds_place') return snapshot.odds_place;
+    return undefined;
+  }
+
+  /**
+   * 경주 시작 X분 전에 가장 가까운 스냅샷 찾기
+   */
+  private findClosestSnapshot(
+    sorted: Array<{ time: Date; odds_win: number; odds_place?: number }>,
+    minutesBefore: number,
+    field: ConditionField
+  ): number | undefined {
+    // 마지막 스냅샷을 경주 시작 시간으로 가정
+    const lastTime = sorted[sorted.length - 1].time;
+    const targetTime = new Date(lastTime.getTime() - minutesBefore * 60 * 1000);
+
+    // 타겟 시간에 가장 가까운 스냅샷 찾기
+    let closest = sorted[0];
+    let minDiff = Math.abs(sorted[0].time.getTime() - targetTime.getTime());
+
+    for (const snapshot of sorted) {
+      const diff = Math.abs(snapshot.time.getTime() - targetTime.getTime());
+      if (diff < minDiff) {
+        minDiff = diff;
+        closest = snapshot;
+      }
+    }
+
+    return this.getOddsFromSnapshot(closest, field);
+  }
+
+  /**
+   * 연산자별 값 비교
+   */
+  private compareValues(
+    operator: ConditionOperator,
+    actual: number,
+    expected: number | string | [number, number] | number[] | string[]
+  ): boolean {
+    switch (operator) {
+      case 'eq':
+        return actual === expected;
+
+      case 'ne':
+        return actual !== expected;
+
+      case 'gt':
+        return actual > (expected as number);
+
+      case 'gte':
+        return actual >= (expected as number);
+
+      case 'lt':
+        return actual < (expected as number);
+
+      case 'lte':
+        return actual <= (expected as number);
+
+      case 'between': {
+        const [min, max] = expected as [number, number];
+        return actual >= min && actual <= max;
+      }
+
+      case 'in': {
+        const list = expected as number[];
+        return list.includes(actual);
+      }
+
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * 필터 조건 확인
+   */
+  private passesFilters(race: RaceContext): boolean {
+    const filters = this.strategy.filters;
+    if (!filters) return true;
+
+    // 경주 유형 필터
+    if (filters.raceTypes && !filters.raceTypes.includes(race.raceType)) {
+      return false;
+    }
+
+    // 경주장 필터
+    if (filters.tracks && !filters.tracks.includes(race.track)) {
+      return false;
+    }
+
+    // 등급 필터
+    if (filters.grades && race.grade && !filters.grades.includes(race.grade)) {
+      return false;
+    }
+
+    // 최소 출주 마리 수
+    if (filters.minEntries && race.entries.length < filters.minEntries) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 전략 정보 조회
+   */
+  getStrategy(): StrategyDefinition {
+    return this.strategy;
+  }
+
+  /**
+   * 지원하는 필드 목록 반환 (현재 구현된 Phase 기준)
+   */
+  static getSupportedFields(maxPhase: 0 | 1 | 2 = 0): ConditionField[] {
+    return (Object.keys(FIELD_METADATA) as ConditionField[]).filter(
+      (field) => FIELD_METADATA[field].phase <= maxPhase
+    );
+  }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * 배당률 드리프트 계산
+ * @param firstOdds 최초 배당률
+ * @param lastOdds 최종 배당률
+ * @returns 변화율 (%)
+ */
+export function calculateOddsDrift(firstOdds: number, lastOdds: number): number {
+  if (firstOdds === 0) return 0;
+  return ((lastOdds - firstOdds) / firstOdds) * 100;
+}
+
+/**
+ * 배당률 표준편차 계산
+ * @param oddsList 배당률 배열
+ * @returns 표준편차
+ */
+export function calculateOddsStdDev(oddsList: number[]): number {
+  if (oddsList.length === 0) return 0;
+
+  const mean = oddsList.reduce((a, b) => a + b, 0) / oddsList.length;
+  const squaredDiffs = oddsList.map((x) => Math.pow(x - mean, 2));
+  const variance = squaredDiffs.reduce((a, b) => a + b, 0) / oddsList.length;
+
+  return Math.sqrt(variance);
+}
+
+/**
+ * 매출 비율 계산
+ * @param entryPool 특정 마번의 매출
+ * @param totalPool 총 매출
+ * @returns 비율 (%)
+ */
+export function calculatePoolPercentage(entryPool: number, totalPool: number): number {
+  if (totalPool === 0) return 0;
+  return (entryPool / totalPool) * 100;
+}
+
+/**
+ * 편의 함수: 전략으로 경주 평가
+ */
+export function evaluateRace(
+  strategy: StrategyDefinition,
+  race: RaceContext
+): EvaluationResult[] {
+  const evaluator = new StrategyEvaluator(strategy);
+  return evaluator.evaluateRace(race);
+}
+
+/**
+ * 편의 함수: 여러 경주 일괄 평가
+ */
+export function evaluateRaces(
+  strategy: StrategyDefinition,
+  races: RaceContext[]
+): Map<string, EvaluationResult[]> {
+  const evaluator = new StrategyEvaluator(strategy);
+  const results = new Map<string, EvaluationResult[]>();
+
+  for (const race of races) {
+    const raceResults = evaluator.evaluateRace(race);
+    if (raceResults.length > 0) {
+      results.set(race.raceId, raceResults);
+    }
+  }
+
+  return results;
+}

--- a/src/lib/strategy/index.ts
+++ b/src/lib/strategy/index.ts
@@ -1,0 +1,63 @@
+/**
+ * Strategy Module
+ *
+ * Strategy DSL 정의, 검증, 평가를 위한 모듈
+ */
+
+// Types
+export type {
+  ConditionField,
+  ConditionOperator,
+  TimeReference,
+  BetAction,
+  StrategyCondition,
+  StrategyDefinition,
+  BacktestRequest,
+  BetRecord,
+  BacktestSummary,
+  EquityPoint,
+  BacktestResult,
+  StrategyValidationError,
+  ValidationResult,
+  FieldMetadata,
+  OperatorMetadata,
+} from './types';
+
+// Constants
+export {
+  FIELD_METADATA,
+  OPERATOR_METADATA,
+  MAX_CONDITIONS,
+  MAX_BACKTEST_DAYS,
+  DEFAULT_INITIAL_CAPITAL,
+  DEFAULT_BET_AMOUNT,
+} from './types';
+
+// Validator
+export {
+  validateStrategy,
+  validateCondition,
+  validateBacktestRequest,
+  parseStrategy,
+  safeParseStrategy,
+  isValidStrategy,
+  isValidCondition,
+  getAllowedFields,
+  getAllowedOperators,
+  getAllowedTimeRefs,
+  getFieldsByPhase,
+} from './validator';
+
+// Evaluator
+export {
+  StrategyEvaluator,
+  evaluateRace,
+  evaluateRaces,
+  calculateOddsDrift,
+  calculateOddsStdDev,
+  calculatePoolPercentage,
+  type EntryContext,
+  type RaceContext,
+  type EvaluationResult,
+  type ConditionResult,
+} from './evaluator';

--- a/src/lib/strategy/types.ts
+++ b/src/lib/strategy/types.ts
@@ -1,0 +1,510 @@
+/**
+ * Strategy DSL Type Definitions
+ *
+ * JSON 기반 베팅 전략 정의를 위한 타입 시스템
+ * 보안을 위해 eval() 없이 whitelist 기반 파싱만 허용
+ */
+
+// =============================================================================
+// Condition Fields - 전략 조건에 사용 가능한 필드
+// =============================================================================
+
+/**
+ * 조건 평가에 사용할 수 있는 필드 목록
+ * Phase 0: 배당률 관련 기본 필드
+ * Phase 2+: 기수/조교사 통계 확장 예정
+ */
+export type ConditionField =
+  // 배당률 관련 (Phase 0)
+  | 'odds_win' // 단승 배당률
+  | 'odds_place' // 복승 배당률
+  | 'odds_drift_pct' // 배당률 변화율 (%) = (last - first) / first * 100
+  | 'odds_stddev' // 배당률 표준편차 (변동성)
+  // 수급 관련 (Phase 0)
+  | 'popularity_rank' // 인기순위 (1 = 가장 인기)
+  | 'pool_total' // 총 매출액 (KRW)
+  | 'pool_win_pct' // 단승 매출 비율 (%)
+  // 경주마 정보 (Phase 1)
+  | 'horse_rating' // 마 레이팅
+  | 'burden_weight' // 부담중량 (kg)
+  | 'entry_count'; // 출주 마리 수
+// 기수/조교사 (Phase 2 - 외부 데이터 필요)
+// | 'jockey_win_rate'    // 기수 승률
+// | 'trainer_win_rate'   // 조교사 승률
+
+/**
+ * 필드별 메타데이터 - 검증 및 UI 표시용
+ */
+export interface FieldMetadata {
+  field: ConditionField;
+  label: string;
+  description: string;
+  unit?: string;
+  min?: number;
+  max?: number;
+  phase: 0 | 1 | 2; // 구현 단계
+}
+
+export const FIELD_METADATA: Record<ConditionField, FieldMetadata> = {
+  odds_win: {
+    field: 'odds_win',
+    label: '단승 배당률',
+    description: '해당 마번의 단승 배당률',
+    unit: '배',
+    min: 1.0,
+    max: 999.9,
+    phase: 0,
+  },
+  odds_place: {
+    field: 'odds_place',
+    label: '복승 배당률',
+    description: '해당 마번의 복승 배당률',
+    unit: '배',
+    min: 1.0,
+    max: 999.9,
+    phase: 0,
+  },
+  odds_drift_pct: {
+    field: 'odds_drift_pct',
+    label: '배당 변화율',
+    description: '경주 시작 전 배당률 변화 (음수 = 하락)',
+    unit: '%',
+    min: -100,
+    max: 1000,
+    phase: 0,
+  },
+  odds_stddev: {
+    field: 'odds_stddev',
+    label: '배당 변동성',
+    description: '배당률의 표준편차 (높을수록 변동 큼)',
+    unit: '',
+    min: 0,
+    max: 100,
+    phase: 0,
+  },
+  popularity_rank: {
+    field: 'popularity_rank',
+    label: '인기순위',
+    description: '매출 기준 인기순위 (1 = 가장 인기)',
+    min: 1,
+    max: 20,
+    phase: 0,
+  },
+  pool_total: {
+    field: 'pool_total',
+    label: '총 매출액',
+    description: '해당 경주의 총 베팅 매출액',
+    unit: 'KRW',
+    min: 0,
+    phase: 0,
+  },
+  pool_win_pct: {
+    field: 'pool_win_pct',
+    label: '단승 매출 비율',
+    description: '총 매출 중 해당 마번의 단승 매출 비율',
+    unit: '%',
+    min: 0,
+    max: 100,
+    phase: 0,
+  },
+  horse_rating: {
+    field: 'horse_rating',
+    label: '마 레이팅',
+    description: '경주마의 능력 지수',
+    min: 0,
+    max: 150,
+    phase: 1,
+  },
+  burden_weight: {
+    field: 'burden_weight',
+    label: '부담중량',
+    description: '경주마가 지는 중량',
+    unit: 'kg',
+    min: 45,
+    max: 65,
+    phase: 1,
+  },
+  entry_count: {
+    field: 'entry_count',
+    label: '출주 마리 수',
+    description: '해당 경주의 총 출주 마리 수',
+    min: 2,
+    max: 16,
+    phase: 1,
+  },
+};
+
+// =============================================================================
+// Condition Operators - 비교 연산자
+// =============================================================================
+
+/**
+ * 지원하는 비교 연산자
+ */
+export type ConditionOperator =
+  | 'eq' // 같다 (==)
+  | 'ne' // 다르다 (!=)
+  | 'gt' // 크다 (>)
+  | 'gte' // 크거나 같다 (>=)
+  | 'lt' // 작다 (<)
+  | 'lte' // 작거나 같다 (<=)
+  | 'between' // 범위 내 (min <= x <= max)
+  | 'in'; // 목록 포함
+
+/**
+ * 연산자별 메타데이터
+ */
+export interface OperatorMetadata {
+  operator: ConditionOperator;
+  label: string;
+  symbol: string;
+  requiresRange: boolean; // between용
+  requiresList: boolean; // in용
+}
+
+export const OPERATOR_METADATA: Record<ConditionOperator, OperatorMetadata> = {
+  eq: { operator: 'eq', label: '같다', symbol: '=', requiresRange: false, requiresList: false },
+  ne: { operator: 'ne', label: '다르다', symbol: '≠', requiresRange: false, requiresList: false },
+  gt: { operator: 'gt', label: '크다', symbol: '>', requiresRange: false, requiresList: false },
+  gte: {
+    operator: 'gte',
+    label: '크거나 같다',
+    symbol: '≥',
+    requiresRange: false,
+    requiresList: false,
+  },
+  lt: { operator: 'lt', label: '작다', symbol: '<', requiresRange: false, requiresList: false },
+  lte: {
+    operator: 'lte',
+    label: '작거나 같다',
+    symbol: '≤',
+    requiresRange: false,
+    requiresList: false,
+  },
+  between: {
+    operator: 'between',
+    label: '범위 내',
+    symbol: '∈',
+    requiresRange: true,
+    requiresList: false,
+  },
+  in: { operator: 'in', label: '포함', symbol: '∈', requiresRange: false, requiresList: true },
+};
+
+// =============================================================================
+// Time Reference - 시간 참조점
+// =============================================================================
+
+/**
+ * 시계열 데이터의 시간 참조점
+ * 배당률은 경주 전까지 계속 변하므로 어느 시점의 값을 사용할지 지정
+ */
+export type TimeReference =
+  | 'first' // 최초 수집 시점
+  | 'last' // 최종 수집 시점 (경주 직전)
+  | 'T-5m' // 경주 5분 전
+  | 'T-15m' // 경주 15분 전
+  | 'T-30m' // 경주 30분 전
+  | 'T-60m'; // 경주 60분 전
+
+// =============================================================================
+// Strategy Condition - 단일 조건
+// =============================================================================
+
+/**
+ * 단일 조건 정의
+ */
+export interface StrategyCondition {
+  /** 평가할 필드 */
+  field: ConditionField;
+
+  /** 비교 연산자 */
+  operator: ConditionOperator;
+
+  /**
+   * 비교 값
+   * - 단일 값: number | string
+   * - between: [min, max]
+   * - in: number[] | string[]
+   */
+  value: number | string | [number, number] | number[] | string[];
+
+  /**
+   * 시간 참조점 (선택)
+   * 기본값: 'last' (최종 배당률)
+   */
+  timeRef?: TimeReference;
+}
+
+// =============================================================================
+// Bet Action - 베팅 액션
+// =============================================================================
+
+/**
+ * 조건 충족 시 실행할 액션
+ */
+export type BetAction =
+  | 'bet_win' // 단승 베팅
+  | 'bet_place' // 복승 베팅
+  | 'bet_quinella' // 연승 베팅 (추후)
+  | 'skip'; // 베팅 안함
+
+// =============================================================================
+// Strategy Definition - 전략 정의
+// =============================================================================
+
+/**
+ * 완전한 전략 정의
+ */
+export interface StrategyDefinition {
+  /** 고유 식별자 (UUID 권장) */
+  id: string;
+
+  /** 전략 이름 */
+  name: string;
+
+  /** 버전 (semver) */
+  version: string;
+
+  /**
+   * 진입 조건 목록
+   * 모든 조건이 AND로 결합됨
+   * 복잡한 OR 조건은 별도 전략으로 분리 권장
+   */
+  conditions: StrategyCondition[];
+
+  /** 조건 충족 시 실행할 액션 */
+  action: BetAction;
+
+  /**
+   * 베팅 금액 설정 (선택)
+   */
+  stake?: {
+    /** 고정 금액 (KRW) */
+    fixed?: number;
+    /** 자본 대비 비율 (%) */
+    percentOfBankroll?: number;
+    /** Kelly Criterion 적용 여부 */
+    useKelly?: boolean;
+  };
+
+  /**
+   * 필터 조건 (선택)
+   * 백테스트 대상 경주 제한
+   */
+  filters?: {
+    /** 경주 유형 */
+    raceTypes?: ('horse' | 'cycle' | 'boat')[];
+    /** 경주장 코드 */
+    tracks?: string[];
+    /** 등급 */
+    grades?: string[];
+    /** 최소 출주 마리 수 */
+    minEntries?: number;
+  };
+
+  /** 메타데이터 */
+  metadata: {
+    /** 작성자 */
+    author: string;
+    /** 생성일 (ISO 8601) */
+    createdAt: string;
+    /** 수정일 (ISO 8601) */
+    updatedAt?: string;
+    /** 설명 */
+    description?: string;
+    /** 태그 */
+    tags?: string[];
+  };
+}
+
+// =============================================================================
+// Backtest Request/Result Types
+// =============================================================================
+
+/**
+ * 백테스트 요청
+ */
+export interface BacktestRequest {
+  /** 테스트할 전략 */
+  strategy: StrategyDefinition;
+
+  /** 테스트 기간 */
+  dateRange: {
+    from: string; // ISO date (YYYY-MM-DD)
+    to: string; // ISO date (YYYY-MM-DD)
+  };
+
+  /** 초기 자본금 (KRW) */
+  initialCapital?: number;
+
+  /** 추가 필터 (전략 필터 오버라이드) */
+  filters?: StrategyDefinition['filters'];
+}
+
+/**
+ * 개별 베팅 기록
+ */
+export interface BetRecord {
+  /** 경주 ID */
+  raceId: string;
+
+  /** 경주 날짜 */
+  raceDate: string;
+
+  /** 경주장 */
+  track: string;
+
+  /** 경주 번호 */
+  raceNo: number;
+
+  /** 베팅한 마번 */
+  entryNo: number;
+
+  /** 베팅 금액 */
+  betAmount: number;
+
+  /** 베팅 시점 배당률 */
+  oddsAtBet: number;
+
+  /** 결과 */
+  result: 'win' | 'lose' | 'refund';
+
+  /** 손익 */
+  profit: number;
+
+  /** 베팅 후 누적 자본 */
+  cumulativeCapital: number;
+}
+
+/**
+ * 백테스트 결과 요약
+ */
+export interface BacktestSummary {
+  /** 분석 대상 총 경주 수 */
+  totalRaces: number;
+
+  /** 조건 충족한 경주 수 */
+  matchedRaces: number;
+
+  /** 실제 베팅 횟수 */
+  totalBets: number;
+
+  /** 승리 횟수 */
+  wins: number;
+
+  /** 패배 횟수 */
+  losses: number;
+
+  /** 환불 횟수 */
+  refunds: number;
+
+  /** 승률 (%) */
+  winRate: number;
+
+  /** 총 수익 (KRW) */
+  totalProfit: number;
+
+  /** ROI (%) = 총수익 / 총베팅액 * 100 */
+  roi: number;
+
+  /** 최대 낙폭 MDD (%) */
+  maxDrawdown: number;
+
+  /** 최종 자본 (KRW) */
+  finalCapital: number;
+
+  /** 자본 대비 수익률 (%) */
+  capitalReturn: number;
+
+  /** 평균 배당률 */
+  avgOdds: number;
+
+  /** 평균 베팅 금액 */
+  avgBetAmount: number;
+
+  /** 최대 연승 */
+  maxWinStreak: number;
+
+  /** 최대 연패 */
+  maxLoseStreak: number;
+}
+
+/**
+ * 자본 곡선 데이터 포인트
+ */
+export interface EquityPoint {
+  date: string;
+  capital: number;
+  drawdown: number;
+}
+
+/**
+ * 완전한 백테스트 결과
+ */
+export interface BacktestResult {
+  /** 요청 정보 */
+  request: BacktestRequest;
+
+  /** 결과 요약 */
+  summary: BacktestSummary;
+
+  /** 개별 베팅 기록 */
+  bets: BetRecord[];
+
+  /** 자본 곡선 */
+  equityCurve: EquityPoint[];
+
+  /** 실행 메타데이터 */
+  executedAt: string;
+  executionTimeMs: number;
+}
+
+// =============================================================================
+// Validation Error Types
+// =============================================================================
+
+/**
+ * 전략 검증 오류
+ */
+export interface StrategyValidationError {
+  path: string; // e.g., "conditions[0].field"
+  message: string;
+  code:
+    | 'INVALID_FIELD'
+    | 'INVALID_OPERATOR'
+    | 'INVALID_VALUE'
+    | 'INVALID_TIME_REF'
+    | 'EMPTY_CONDITIONS'
+    | 'TOO_MANY_CONDITIONS'
+    | 'INVALID_DATE_RANGE'
+    | 'SCHEMA_ERROR';
+}
+
+/**
+ * 검증 결과
+ */
+export interface ValidationResult {
+  valid: boolean;
+  errors: StrategyValidationError[];
+  warnings?: string[];
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** 최대 조건 수 */
+export const MAX_CONDITIONS = 10;
+
+/** 최대 백테스트 기간 (일) - 티어별로 다름 */
+export const MAX_BACKTEST_DAYS = {
+  Gold: 90,
+  QuantLab: 365,
+} as const;
+
+/** 기본 초기 자본금 */
+export const DEFAULT_INITIAL_CAPITAL = 1_000_000; // 100만원
+
+/** 기본 고정 베팅 금액 */
+export const DEFAULT_BET_AMOUNT = 10_000; // 1만원

--- a/src/lib/strategy/validator.test.ts
+++ b/src/lib/strategy/validator.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Strategy DSL Validator Tests
+ */
+
+import {
+  validateStrategy,
+  validateCondition,
+  validateBacktestRequest,
+  parseStrategy,
+  safeParseStrategy,
+  isValidStrategy,
+  getFieldsByPhase,
+} from './validator';
+import type { StrategyDefinition, StrategyCondition } from './types';
+
+describe('Strategy Validator', () => {
+  const validStrategy: StrategyDefinition = {
+    id: 'test-strategy-1',
+    name: '테스트 전략',
+    version: '1.0.0',
+    conditions: [
+      {
+        field: 'odds_drift_pct',
+        operator: 'lt',
+        value: -20,
+        timeRef: 'last',
+      },
+      {
+        field: 'popularity_rank',
+        operator: 'lte',
+        value: 3,
+      },
+    ],
+    action: 'bet_win',
+    metadata: {
+      author: 'test',
+      createdAt: '2025-01-01T00:00:00Z',
+      description: '배당률 급락 모멘텀 전략',
+    },
+  };
+
+  describe('validateStrategy', () => {
+    it('should validate a correct strategy', () => {
+      const result = validateStrategy(validStrategy);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject strategy with invalid field', () => {
+      const invalid = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'invalid_field',
+            operator: 'gt',
+            value: 10,
+          },
+        ],
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('INVALID_FIELD');
+    });
+
+    it('should reject strategy with invalid operator', () => {
+      const invalid = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'odds_win',
+            operator: 'invalid_op',
+            value: 10,
+          },
+        ],
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('INVALID_OPERATOR');
+    });
+
+    it('should reject strategy with empty conditions', () => {
+      const invalid = {
+        ...validStrategy,
+        conditions: [],
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('EMPTY_CONDITIONS');
+    });
+
+    it('should reject strategy with too many conditions', () => {
+      const invalid = {
+        ...validStrategy,
+        conditions: Array(11).fill({
+          field: 'odds_win',
+          operator: 'gt',
+          value: 2,
+        }),
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('TOO_MANY_CONDITIONS');
+    });
+
+    it('should validate between operator with range value', () => {
+      const strategy = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'odds_win',
+            operator: 'between',
+            value: [2.0, 10.0],
+          },
+        ],
+      };
+      const result = validateStrategy(strategy);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject between operator with non-range value', () => {
+      const invalid = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'odds_win',
+            operator: 'between',
+            value: 5, // Should be [min, max]
+          },
+        ],
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should validate in operator with array value', () => {
+      const strategy = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'popularity_rank',
+            operator: 'in',
+            value: [1, 2, 3],
+          },
+        ],
+      };
+      const result = validateStrategy(strategy);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should warn when using Phase 1+ fields', () => {
+      const strategy = {
+        ...validStrategy,
+        conditions: [
+          {
+            field: 'horse_rating', // Phase 1 field
+            operator: 'gte',
+            value: 100,
+          },
+        ],
+      };
+      const result = validateStrategy(strategy);
+      expect(result.valid).toBe(true);
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.[0]).toContain('Phase 1');
+    });
+
+    it('should reject invalid version format', () => {
+      const invalid = {
+        ...validStrategy,
+        version: 'v1.0', // Should be x.y.z
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject invalid ID format', () => {
+      const invalid = {
+        ...validStrategy,
+        id: 'invalid id with spaces',
+      };
+      const result = validateStrategy(invalid);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should validate optional stake configuration', () => {
+      const strategy = {
+        ...validStrategy,
+        stake: {
+          fixed: 10000,
+          percentOfBankroll: 5,
+          useKelly: true,
+        },
+      };
+      const result = validateStrategy(strategy);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should validate optional filters', () => {
+      const strategy = {
+        ...validStrategy,
+        filters: {
+          raceTypes: ['horse', 'cycle'],
+          tracks: ['seoul', 'busan'],
+          minEntries: 8,
+        },
+      };
+      const result = validateStrategy(strategy);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validateCondition', () => {
+    it('should validate a correct condition', () => {
+      const condition: StrategyCondition = {
+        field: 'odds_win',
+        operator: 'gte',
+        value: 2.5,
+      };
+      const result = validateCondition(condition);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject invalid field', () => {
+      const result = validateCondition({
+        field: 'not_a_field',
+        operator: 'gt',
+        value: 1,
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('validateBacktestRequest', () => {
+    const validRequest = {
+      strategy: validStrategy,
+      dateRange: {
+        from: '2024-01-01',
+        to: '2024-03-31',
+      },
+      initialCapital: 1000000,
+    };
+
+    it('should validate a correct backtest request', () => {
+      const result = validateBacktestRequest(validRequest);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject invalid date format', () => {
+      const invalid = {
+        ...validRequest,
+        dateRange: {
+          from: '2024/01/01',
+          to: '2024-03-31',
+        },
+      };
+      const result = validateBacktestRequest(invalid);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject when from > to', () => {
+      const invalid = {
+        ...validRequest,
+        dateRange: {
+          from: '2024-03-31',
+          to: '2024-01-01',
+        },
+      };
+      const result = validateBacktestRequest(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('INVALID_DATE_RANGE');
+    });
+
+    it('should reject period exceeding 365 days', () => {
+      const invalid = {
+        ...validRequest,
+        dateRange: {
+          from: '2022-01-01',
+          to: '2024-01-01',
+        },
+      };
+      const result = validateBacktestRequest(invalid);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].code).toBe('INVALID_DATE_RANGE');
+    });
+  });
+
+  describe('parseStrategy', () => {
+    it('should parse valid JSON string', () => {
+      const jsonString = JSON.stringify(validStrategy);
+      const parsed = parseStrategy(jsonString);
+      expect(parsed.id).toBe(validStrategy.id);
+      expect(parsed.conditions).toHaveLength(2);
+    });
+
+    it('should throw on invalid JSON', () => {
+      expect(() => parseStrategy('not valid json')).toThrow('Invalid JSON format');
+    });
+
+    it('should throw on validation failure', () => {
+      const invalid = JSON.stringify({ ...validStrategy, conditions: [] });
+      expect(() => parseStrategy(invalid)).toThrow('Strategy validation failed');
+    });
+  });
+
+  describe('safeParseStrategy', () => {
+    it('should return success for valid strategy', () => {
+      const result = safeParseStrategy(JSON.stringify(validStrategy));
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+    });
+
+    it('should return error for invalid strategy', () => {
+      const result = safeParseStrategy('invalid');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('isValidStrategy', () => {
+    it('should return true for valid strategy', () => {
+      expect(isValidStrategy(validStrategy)).toBe(true);
+    });
+
+    it('should return false for invalid strategy', () => {
+      expect(isValidStrategy({ invalid: true })).toBe(false);
+    });
+  });
+
+  describe('getFieldsByPhase', () => {
+    it('should return only Phase 0 fields', () => {
+      const fields = getFieldsByPhase(0);
+      expect(fields).toContain('odds_win');
+      expect(fields).toContain('odds_drift_pct');
+      expect(fields).toContain('popularity_rank');
+      expect(fields).not.toContain('horse_rating'); // Phase 1
+    });
+
+    it('should return Phase 0 and 1 fields', () => {
+      const fields = getFieldsByPhase(1);
+      expect(fields).toContain('odds_win');
+      expect(fields).toContain('horse_rating');
+      expect(fields).toContain('burden_weight');
+    });
+  });
+});

--- a/src/lib/strategy/validator.ts
+++ b/src/lib/strategy/validator.ts
@@ -1,0 +1,441 @@
+/**
+ * Strategy DSL Validator
+ *
+ * Zod 기반 전략 정의 검증
+ * 보안: whitelist 기반 필드/연산자만 허용
+ */
+
+import { z } from 'zod';
+import {
+  type StrategyDefinition,
+  type StrategyCondition,
+  type ValidationResult,
+  type StrategyValidationError,
+  type ConditionField,
+  type ConditionOperator,
+  type TimeReference,
+  type BetAction,
+  FIELD_METADATA,
+  OPERATOR_METADATA,
+  MAX_CONDITIONS,
+} from './types';
+
+// =============================================================================
+// Allowed Values (Whitelist)
+// =============================================================================
+
+const ALLOWED_FIELDS: readonly ConditionField[] = Object.keys(FIELD_METADATA) as ConditionField[];
+
+const ALLOWED_OPERATORS: readonly ConditionOperator[] = Object.keys(
+  OPERATOR_METADATA
+) as ConditionOperator[];
+
+const ALLOWED_TIME_REFS: readonly TimeReference[] = [
+  'first',
+  'last',
+  'T-5m',
+  'T-15m',
+  'T-30m',
+  'T-60m',
+];
+
+const ALLOWED_ACTIONS: readonly BetAction[] = ['bet_win', 'bet_place', 'bet_quinella', 'skip'];
+
+const ALLOWED_RACE_TYPES = ['horse', 'cycle', 'boat'] as const;
+
+// =============================================================================
+// Zod Schemas
+// =============================================================================
+
+/**
+ * 조건 필드 스키마
+ */
+const conditionFieldSchema = z.enum(ALLOWED_FIELDS as [ConditionField, ...ConditionField[]]);
+
+/**
+ * 조건 연산자 스키마
+ */
+const conditionOperatorSchema = z.enum(
+  ALLOWED_OPERATORS as [ConditionOperator, ...ConditionOperator[]]
+);
+
+/**
+ * 시간 참조 스키마
+ */
+const timeRefSchema = z.enum(ALLOWED_TIME_REFS as [TimeReference, ...TimeReference[]]);
+
+/**
+ * 조건 값 스키마 - 연산자에 따라 다른 값 타입 허용
+ */
+const conditionValueSchema = z.union([
+  z.number(),
+  z.string(),
+  z.tuple([z.number(), z.number()]), // between 범위
+  z.array(z.number()), // in 목록
+  z.array(z.string()), // in 목록 (문자열)
+]);
+
+/**
+ * 단일 조건 스키마
+ */
+const strategyConditionSchema = z
+  .object({
+    field: conditionFieldSchema,
+    operator: conditionOperatorSchema,
+    value: conditionValueSchema,
+    timeRef: timeRefSchema.optional(),
+  })
+  .refine(
+    (data) => {
+      const op = data.operator as string;
+      // between 연산자는 [min, max] 배열 필요
+      if (op === 'between') {
+        return (
+          Array.isArray(data.value) &&
+          data.value.length === 2 &&
+          typeof data.value[0] === 'number' &&
+          typeof data.value[1] === 'number'
+        );
+      }
+      // in 연산자는 배열 필요
+      if (op === 'in') {
+        return Array.isArray(data.value) && data.value.length > 0;
+      }
+      // 다른 연산자는 단일 값 (배열이면 안됨)
+      return !Array.isArray(data.value);
+    },
+    {
+      message: 'Invalid value type for operator',
+    }
+  );
+
+/**
+ * 베팅 액션 스키마
+ */
+const betActionSchema = z.enum(ALLOWED_ACTIONS as [BetAction, ...BetAction[]]);
+
+/**
+ * 스테이크 설정 스키마
+ */
+const stakeSchema = z
+  .object({
+    fixed: z.number().positive().optional(),
+    percentOfBankroll: z.number().min(0).max(100).optional(),
+    useKelly: z.boolean().optional(),
+  })
+  .optional();
+
+/**
+ * 필터 스키마
+ */
+const filtersSchema = z
+  .object({
+    raceTypes: z.array(z.enum(ALLOWED_RACE_TYPES)).optional(),
+    tracks: z.array(z.string().min(1)).optional(),
+    grades: z.array(z.string().min(1)).optional(),
+    minEntries: z.number().int().min(2).max(20).optional(),
+  })
+  .optional();
+
+/**
+ * 메타데이터 스키마
+ */
+const metadataSchema = z.object({
+  author: z.string().min(1).max(100),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime().optional(),
+  description: z.string().max(1000).optional(),
+  tags: z.array(z.string().min(1).max(50)).max(10).optional(),
+});
+
+/**
+ * 전체 전략 정의 스키마
+ */
+const strategyDefinitionSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1)
+      .max(100)
+      .regex(/^[a-zA-Z0-9_-]+$/, 'ID must be alphanumeric with _ or -'),
+    name: z.string().min(1).max(200),
+    version: z.string().regex(/^\d+\.\d+\.\d+$/, 'Version must be semver format (x.y.z)'),
+    conditions: z.array(strategyConditionSchema).min(1).max(MAX_CONDITIONS),
+    action: betActionSchema,
+    stake: stakeSchema,
+    filters: filtersSchema,
+    metadata: metadataSchema,
+  })
+  .strict(); // 추가 필드 허용 안함
+
+/**
+ * 백테스트 요청 스키마
+ */
+const backtestRequestSchema = z.object({
+  strategy: strategyDefinitionSchema,
+  dateRange: z.object({
+    from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format'),
+    to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format'),
+  }),
+  initialCapital: z.number().positive().optional(),
+  filters: filtersSchema,
+});
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
+
+/**
+ * 전략 정의 검증
+ */
+export function validateStrategy(input: unknown): ValidationResult {
+  const result = strategyDefinitionSchema.safeParse(input);
+
+  if (result.success) {
+    // 추가 비즈니스 로직 검증
+    const warnings: string[] = [];
+    const strategy = result.data as StrategyDefinition;
+
+    // Phase 1+ 필드 사용 경고
+    for (const condition of strategy.conditions) {
+      const metadata = FIELD_METADATA[condition.field];
+      if (metadata.phase > 0) {
+        warnings.push(
+          `Field '${condition.field}' is Phase ${metadata.phase} feature and may have limited data`
+        );
+      }
+    }
+
+    // 배당 변화율 사용 시 timeRef 권장
+    const hasDriftCondition = strategy.conditions.some((c) => c.field === 'odds_drift_pct');
+    if (hasDriftCondition) {
+      const driftConditions = strategy.conditions.filter((c) => c.field === 'odds_drift_pct');
+      for (const c of driftConditions) {
+        if (!c.timeRef) {
+          warnings.push(
+            "odds_drift_pct condition without timeRef will use default 'last' (final odds)"
+          );
+        }
+      }
+    }
+
+    return {
+      valid: true,
+      errors: [],
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+  }
+
+  // Zod 오류를 ValidationError로 변환
+  // Zod 4.x uses .issues, Zod 3.x uses .errors
+  const zodErrors = result.error?.issues ?? [];
+  const errors: StrategyValidationError[] = zodErrors.map((err: z.ZodIssue) => ({
+    path: err.path.join('.'),
+    message: err.message,
+    code: mapZodErrorToCode(err),
+  }));
+
+  return {
+    valid: false,
+    errors,
+  };
+}
+
+/**
+ * 백테스트 요청 검증
+ */
+export function validateBacktestRequest(input: unknown): ValidationResult {
+  const result = backtestRequestSchema.safeParse(input);
+
+  if (result.success) {
+    const data = result.data;
+
+    // 날짜 범위 검증
+    const fromDate = new Date(data.dateRange.from);
+    const toDate = new Date(data.dateRange.to);
+
+    if (fromDate > toDate) {
+      return {
+        valid: false,
+        errors: [
+          {
+            path: 'dateRange',
+            message: 'from date must be before to date',
+            code: 'INVALID_DATE_RANGE',
+          },
+        ],
+      };
+    }
+
+    // 최대 기간 검증은 티어별로 다르므로 여기서는 기본 검증만
+    const daysDiff = Math.ceil((toDate.getTime() - fromDate.getTime()) / (1000 * 60 * 60 * 24));
+    if (daysDiff > 365) {
+      return {
+        valid: false,
+        errors: [
+          {
+            path: 'dateRange',
+            message: 'Maximum backtest period is 365 days',
+            code: 'INVALID_DATE_RANGE',
+          },
+        ],
+      };
+    }
+
+    return { valid: true, errors: [] };
+  }
+
+  const zodErrors = result.error?.issues ?? [];
+  const errors: StrategyValidationError[] = zodErrors.map((err: z.ZodIssue) => ({
+    path: err.path.join('.'),
+    message: err.message,
+    code: mapZodErrorToCode(err),
+  }));
+
+  return { valid: false, errors };
+}
+
+/**
+ * 단일 조건 검증 (유틸리티)
+ */
+export function validateCondition(input: unknown): ValidationResult {
+  const result = strategyConditionSchema.safeParse(input);
+
+  if (result.success) {
+    return { valid: true, errors: [] };
+  }
+
+  const zodErrors = result.error?.issues ?? [];
+  const errors: StrategyValidationError[] = zodErrors.map((err: z.ZodIssue) => ({
+    path: err.path.join('.'),
+    message: err.message,
+    code: mapZodErrorToCode(err),
+  }));
+
+  return { valid: false, errors };
+}
+
+// =============================================================================
+// Type Guards
+// =============================================================================
+
+/**
+ * StrategyDefinition 타입 가드
+ */
+export function isValidStrategy(input: unknown): input is StrategyDefinition {
+  return validateStrategy(input).valid;
+}
+
+/**
+ * StrategyCondition 타입 가드
+ */
+export function isValidCondition(input: unknown): input is StrategyCondition {
+  return validateCondition(input).valid;
+}
+
+// =============================================================================
+// Parsing Functions (with validation)
+// =============================================================================
+
+/**
+ * JSON 문자열을 StrategyDefinition으로 파싱
+ * @throws Error if invalid JSON or validation fails
+ */
+export function parseStrategy(jsonString: string): StrategyDefinition {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch {
+    throw new Error('Invalid JSON format');
+  }
+
+  const validation = validateStrategy(parsed);
+  if (!validation.valid) {
+    const errorMessages = validation.errors.map((e) => `${e.path}: ${e.message}`).join('; ');
+    throw new Error(`Strategy validation failed: ${errorMessages}`);
+  }
+
+  return parsed as StrategyDefinition;
+}
+
+/**
+ * 안전한 파싱 (에러 대신 결과 객체 반환)
+ */
+export function safeParseStrategy(jsonString: string): {
+  success: boolean;
+  data?: StrategyDefinition;
+  error?: string;
+} {
+  try {
+    const data = parseStrategy(jsonString);
+    return { success: true, data };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Zod 오류를 커스텀 오류 코드로 매핑
+ */
+function mapZodErrorToCode(
+  err: z.ZodIssue
+): StrategyValidationError['code'] {
+  const path = err.path.join('.');
+
+  if (path.includes('field')) return 'INVALID_FIELD';
+  if (path.includes('operator')) return 'INVALID_OPERATOR';
+  if (path.includes('value')) return 'INVALID_VALUE';
+  if (path.includes('timeRef')) return 'INVALID_TIME_REF';
+  if (path.includes('conditions') && err.code === 'too_small') return 'EMPTY_CONDITIONS';
+  if (path.includes('conditions') && err.code === 'too_big') return 'TOO_MANY_CONDITIONS';
+  if (path.includes('dateRange')) return 'INVALID_DATE_RANGE';
+
+  return 'SCHEMA_ERROR';
+}
+
+/**
+ * 허용된 필드 목록 반환 (UI용)
+ */
+export function getAllowedFields(): readonly ConditionField[] {
+  return ALLOWED_FIELDS;
+}
+
+/**
+ * 허용된 연산자 목록 반환 (UI용)
+ */
+export function getAllowedOperators(): readonly ConditionOperator[] {
+  return ALLOWED_OPERATORS;
+}
+
+/**
+ * 허용된 시간 참조 목록 반환 (UI용)
+ */
+export function getAllowedTimeRefs(): readonly TimeReference[] {
+  return ALLOWED_TIME_REFS;
+}
+
+/**
+ * 특정 Phase까지의 필드만 반환
+ */
+export function getFieldsByPhase(maxPhase: 0 | 1 | 2): ConditionField[] {
+  return ALLOWED_FIELDS.filter((field) => FIELD_METADATA[field].phase <= maxPhase);
+}
+
+// =============================================================================
+// Export Schemas (for external validation)
+// =============================================================================
+
+export {
+  strategyDefinitionSchema,
+  strategyConditionSchema,
+  backtestRequestSchema,
+  conditionFieldSchema,
+  conditionOperatorSchema,
+};


### PR DESCRIPTION
## Summary

Quant Terminal MVP 구현 (Phase 0+1)

- **Strategy DSL Module**: JSON 기반 베팅 전략 정의 및 검증 시스템
- **Backtest Engine**: 스트림 기반 백테스팅 실행 엔진
- **B2B API Endpoints**: 백테스트 작업 생성/조회/취소 API
- **QuantLab Tier**: 무제한 백테스트 접근 권한 신규 티어

### New Files

#### Strategy DSL (`src/lib/strategy/`)
- `types.ts` - 전략 타입 정의 (ConditionField, Operator, Strategy 등)
- `validator.ts` - Zod 기반 전략 검증
- `evaluator.ts` - 조건 평가 엔진
- `evaluator.test.ts` / `validator.test.ts` - 53개 테스트

#### Backtest Engine (`src/lib/backtest/`)
- `executor.ts` - 백테스트 실행기
- `metrics.ts` - 성과 지표 계산 (Sharpe, Drawdown, Profit Factor)
- `jobManager.ts` - Vercel KV 작업 상태 관리
- `types.ts` - Job/Quota 타입

#### API Endpoints
| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/backtest` | POST | 백테스트 작업 생성 |
| `/api/v1/backtest` | GET | 작업 목록 조회 |
| `/api/v1/backtest/[jobId]` | GET | 작업 상태 조회 |
| `/api/v1/backtest/[jobId]` | DELETE | 작업 취소 |
| `/api/v1/backtest/[jobId]/result` | GET | 결과 조회 |
| `/api/jobs/backtest/worker` | POST | QStash 웹훅 핸들러 |

### Modified Files
- `package.json` - 의존성 추가 (@upstash/qstash, @vercel/kv, zod)
- `src/lib/db/schema/clients.ts` - QuantLab 티어 및 백테스트 quota 필드
- `src/app/api/v1/data/odds-history/[raceId]/route.ts` - QuantLab 티어 한도

### Database Migration
- `db/migrations/004_quantlab_tier.sql` - QuantLab enum, 백테스트 테이블

## Test plan
- [x] TypeScript 컴파일 오류 없음
- [x] ESLint 오류 없음
- [x] 53개 Strategy DSL 테스트 통과
- [x] Production 빌드 성공

## Related
- Phase 2 Issue: x-ordo/racelab-core#84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a JSON-based strategy DSL and asynchronous backtest engine with job management, quotas, and B2B APIs, including a new QuantLab client tier with expanded backtesting capabilities.

New Features:
- Add a Strategy DSL module for defining, validating, and evaluating betting strategies over historical race data.
- Implement a backtest engine that executes strategies against race data, computes performance metrics, and supports mock data sources for testing.
- Introduce asynchronous backtest job management with Vercel KV and Upstash QStash integration, including worker processing and checkpointing.
- Expose B2B API endpoints to create, list, inspect, cancel, and retrieve results for backtest jobs.
- Add a QuantLab client tier with unlimited or expanded backtest quotas and higher data limits.

Enhancements:
- Extend client tier configuration and odds-history API limits to support backtest-specific quotas and higher limits for premium tiers.

Build:
- Add dependencies for QStash, Vercel KV, Zod, and UUID typings to support backtesting, validation, and job orchestration.

Deployment:
- Add database migrations defining QuantLab tier, backtest job/result/usage tables, and quota reset/cleanup routines.

Tests:
- Add initial (placeholder) test files for the strategy evaluator and validator modules.